### PR TITLE
Add socket check before waiting for database connection

### DIFF
--- a/apache/entrypoint.sh
+++ b/apache/entrypoint.sh
@@ -5,6 +5,7 @@
 DB_TYPE=${DB_TYPE:-'mysql'}
 DB_HOST=${DB_HOST:-'mysql'}
 DB_PORT=${DB_PORT:-'3306'}
+DB_SOCK=${DB_SOCK:-}
 DB_NAME=${DB_NAME:-'limesurvey'}
 DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-'lime_'}
 DB_USERNAME=${DB_USERNAME:-'limesurvey'}
@@ -20,11 +21,13 @@ URL_FORMAT=${URL_FORMAT:-'path'}
 
 
 # Check if database is available
-until nc -z -v -w30 $DB_HOST $DB_PORT
-do
-    echo "Info: Waiting for database connection..."
-    sleep 5
-done
+if [ -z "$DB_SOCK" ]; then
+    until nc -z -v -w30 $DB_HOST $DB_PORT
+    do
+        echo "Info: Waiting for database connection..."
+        sleep 5
+    done
+fi
 
 
 # Check if already provisioned

--- a/fpm-alpine/entrypoint.sh
+++ b/fpm-alpine/entrypoint.sh
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/bin/bash
 # Entrypoint for Docker Container
 
 
 DB_TYPE=${DB_TYPE:-'mysql'}
 DB_HOST=${DB_HOST:-'mysql'}
 DB_PORT=${DB_PORT:-'3306'}
+DB_SOCK=${DB_SOCK:-}
 DB_NAME=${DB_NAME:-'limesurvey'}
 DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-'lime_'}
 DB_USERNAME=${DB_USERNAME:-'limesurvey'}
@@ -20,11 +21,13 @@ URL_FORMAT=${URL_FORMAT:-'path'}
 
 
 # Check if database is available
-until nc -z -v -w30 $DB_HOST $DB_PORT
-do
-    echo "Info: Waiting for database connection..."
-    sleep 5
-done
+if [ -z "$DB_SOCK" ]; then
+    until nc -z -v -w30 $DB_HOST $DB_PORT
+    do
+        echo "Info: Waiting for database connection..."
+        sleep 5
+    done
+fi
 
 
 # Check if already provisioned

--- a/fpm/entrypoint.sh
+++ b/fpm/entrypoint.sh
@@ -5,6 +5,7 @@
 DB_TYPE=${DB_TYPE:-'mysql'}
 DB_HOST=${DB_HOST:-'mysql'}
 DB_PORT=${DB_PORT:-'3306'}
+DB_SOCK=${DB_SOCK:-}
 DB_NAME=${DB_NAME:-'limesurvey'}
 DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-'lime_'}
 DB_USERNAME=${DB_USERNAME:-'limesurvey'}
@@ -20,11 +21,13 @@ URL_FORMAT=${URL_FORMAT:-'path'}
 
 
 # Check if database is available
-until nc -z -v -w30 $DB_HOST $DB_PORT
-do
-    echo "Info: Waiting for database connection..."
-    sleep 5
-done
+if [ -z "$DB_SOCK" ]; then
+    until nc -z -v -w30 $DB_HOST $DB_PORT
+    do
+        echo "Info: Waiting for database connection..."
+        sleep 5
+    done
+fi
 
 
 # Check if already provisioned


### PR DESCRIPTION
database connection checking with netcat is only possible when
using a TCP/IP connection, just launch the application when the
user chooses a unix socket