### PR TITLE
Added configuration which adds Nginx with Letsencrypt certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ See the example configuration provided.
 
 # Using the fpm image
 
-To use the fpm image, you need an additional web server that can proxy http-request to the fpm-port of the container. See *docker-compose.fpm.yml* for example
+To use the fpm image, you need an additional web server that can proxy http-request to the fpm-port of the container. See *docker-compose.fpm.yml* for example.
+
+# Using the fpm image with https
+If you would like to run the fpm setup with https, you can get a free certificate from Letsencrypt. As an example, the configuration in *docker-compose.fpm-certbot.yml*
+will take care of getting a certificate and installing it. Please note that you will have to adjust the domain name in the file *examples/nginx-certbot.conf* to match
+the domain used in the *HOSTNAMES* variable in the docker-compose configuration file. If you added both the a domain and the hostname *www* within the domain,
+*nginx-certbot.conf* needs to contain the domain without the hostname. E.g. if you set *"HOSTNAMES=example.org www.example.org"*, the path in *nginx-certbot.conf* needs
+to contain *example.org*.
 
 # Using an external database
 

--- a/docker-compose.fpm-certbot.yml
+++ b/docker-compose.fpm-certbot.yml
@@ -1,0 +1,49 @@
+version: "3.0"
+services:
+  limesurvey:
+    build:
+      context: 4.0/fpm/
+      dockerfile: Dockerfile
+    volumes:
+      - /tmp/upload/surveys:/var/www/html/upload/surveys
+      - lime:/var/www/html
+    links:
+      - lime-db
+    depends_on:
+      - lime-db
+    environment:
+      - "DB_HOST=lime-db"
+      - "DB_PASSWORD=secret"
+      - "ADMIN_PASSWORD=foobar"
+  lime-web:
+    build:
+      context: nginx-certbot/
+      dockerfile: Dockerfile
+    links:
+      - limesurvey
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./examples/nginx-certbot.conf:/etc/nginx/nginx.conf:ro
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+      - lime:/var/www/html
+    environment:
+      - "HOSTNAMES=www.example.com example.com"
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+  lime-db:
+    image: mysql:5.7
+    environment:
+      - "MYSQL_USER=limesurvey"
+      - "MYSQL_DATABASE=limesurvey"
+      - "MYSQL_PASSWORD=secret"
+      - "MYSQL_ROOT_PASSWORD=secret"
+volumes:
+  lime:

--- a/examples/nginx-certbot.conf
+++ b/examples/nginx-certbot.conf
@@ -30,8 +30,8 @@ http {
         charset utf-8;
         include /etc/nginx/mime.types;
 
-        ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/example.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/example.com/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 

--- a/examples/nginx-certbot.conf
+++ b/examples/nginx-certbot.conf
@@ -1,0 +1,57 @@
+worker_processes 1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+        listen 80;
+        server_name _;
+        server_tokens off;
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+    server {
+        listen 443 ssl;
+        index index.php;
+        set $host_path "/var/www/html";
+        root /var/www/html;
+        server_name _;
+        charset utf-8;
+        include /etc/nginx/mime.types;
+
+        ssl_certificate /etc/letsencrypt/live/example.org/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/example.org/privkey.pem;
+        include /etc/letsencrypt/options-ssl-nginx.conf;
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        location / {
+            try_files $uri /index.php?$args;
+        }
+        location ~ ^/(protected|framework|themes/\w+/views) {
+            deny  all;
+        }
+        location ~ \.(js|css|png|jpg|gif|swf|ico|pdf|mov|fla|zip|rar)$ {
+            try_files $uri =404;
+        }
+        location ~ \.php$ {
+            fastcgi_split_path_info  ^(.+\.php)(.*)$;
+            try_files $uri index.php;
+            include fastcgi_params;
+            fastcgi_index index.php;
+            fastcgi_pass  limesurvey:9000;
+            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+            fastcgi_param  SCRIPT_NAME      $fastcgi_script_name;
+        }
+    }
+}

--- a/nginx-certbot/Dockerfile
+++ b/nginx-certbot/Dockerfile
@@ -1,0 +1,10 @@
+FROM nginx
+RUN apt-get update && \
+    apt-get install -y certbot curl python-certbot-nginx && \
+    apt-get -y autoclean; apt-get -y autoremove; \
+    rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod 700 /entrypoint.sh
+
+CMD ["/entrypoint.sh"]

--- a/nginx-certbot/entrypoint.sh
+++ b/nginx-certbot/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+cert_path=/etc/letsencrypt/live/$(echo $HOSTNAMES | awk '{print $1}')
+mkdir -p cert_path
+
+# if there is no certificate yet, get one
+email="--email $CERT_EMAIL"
+if [ -z $CERT_EMAIL ]
+then
+    email='--register-unsafely-without-email'
+fi
+if [ ! -e $cert_path/privkey.pem ]
+then
+    names=""
+    for h in $HOSTNAMES
+    do
+        names=$(echo "$names -d $h")
+    done
+    echo "Getting new certificate..."
+    /usr/bin/curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > /etc/letsencrypt/options-ssl-nginx.conf
+    /usr/bin/curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > /etc/letsencrypt/ssl-dhparams.pem
+    /usr/bin/certbot certonly --standalone $names --agree-tos $email
+fi
+
+nginx -g "daemon off;"


### PR DESCRIPTION
The added configuration comes with a `certbot` container and configures Nginx to use a Letsencrypt certificate to provide https instead of http.