### PR TITLE
Simplify database host values with compose

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - DB_TYPE=pgsql
       - DB_PORT=5432
-      - DB_HOST=limesurvey_db_1.limesurvey_default
+      - DB_HOST=db
       - DB_PASSWORD=example
       - DB_NAME=limesurvey
       - DB_USERNAME=limesurvey

--- a/docker-compose.fpm.alpine.yml
+++ b/docker-compose.fpm.alpine.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - lime-db
     environment:
-      - "DB_HOST=docker-limesurvey_lime-db_1"
+      - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"
       - "ADMIN_PASSWORD=foobar"
   lime-web:

--- a/docker-compose.fpm.yml
+++ b/docker-compose.fpm.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - lime-db
     environment:
-      - "DB_HOST=docker-limesurvey_lime-db_1"
+      - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"
       - "ADMIN_PASSWORD=foobar"
   lime-web:

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - "DB_TYPE=pgsql"
       - "DB_PORT=5432"
-      - "DB_HOST=docker-limesurvey_lime-db_1"
+      - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"
       - "ADMIN_PASSWORD=foobar"
   lime-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "8080:80"
     environment:
-      - "DB_HOST=docker-limesurvey_lime-db_1"
+      - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"
       - "ADMIN_PASSWORD=foobar"
   lime-db:


### PR DESCRIPTION
As hinted out in https://github.com/martialblog/docker-limesurvey/issues/32 it's possible (and more robust) to refer to the database host using its service name (i.e. lime-db or db).

I tested the Dockerfiles after this change.