### PR TITLE
Update Base Images to PHP 7.4

### DIFF
--- a/3.0/apache/Dockerfile
+++ b/3.0/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.4-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.24.3+201027'
 ARG sha256_checksum='f2072e3b8f5789df7b4e625573f785d5d0a7b8ebc217757fafc194606ebfd6d3'
@@ -12,11 +12,13 @@ RUN set -ex; \
         libldap2-dev \
         libfreetype6-dev \
         libjpeg-dev \
+        libonig-dev \
         zlib1g-dev \
         libc-client-dev \
         libkrb5-dev \
         libpng-dev \
         libpq-dev \
+        libzip-dev \
         netcat \
         \
         && apt-get -y autoclean; apt-get -y autoremove; \
@@ -28,7 +30,7 @@ RUN set -ex; \
 
 # Install PHP Plugins and Configure PHP imap plugin
 RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+        docker-php-ext-configure gd && \
         docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
         docker-php-ext-install -j5 \
         exif \

--- a/3.0/fpm-alpine/Dockerfile
+++ b/3.0/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm-alpine
+FROM php:7.4-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.24.3+201027'
 ARG sha256_checksum='f2072e3b8f5789df7b4e625573f785d5d0a7b8ebc217757fafc194606ebfd6d3'
@@ -8,15 +8,17 @@ RUN set -ex; \
         apk add --no-cache --virtual .build-deps \
         freetype-dev \
         libpng-dev \
+        libzip-dev \
         libjpeg-turbo-dev \
         openldap-dev \
+        oniguruma-dev \
         imap-dev \
         postgresql-dev && \
         apk add --no-cache netcat-openbsd bash
 
 # Install PHP Plugins
 RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr ; \
+        docker-php-ext-configure gd && \
         docker-php-ext-configure imap --with-imap-ssl && \
         docker-php-ext-install \
         gd \

--- a/3.0/fpm/Dockerfile
+++ b/3.0/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.4-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.24.3+201027'
 ARG sha256_checksum='f2072e3b8f5789df7b4e625573f785d5d0a7b8ebc217757fafc194606ebfd6d3'
@@ -12,11 +12,13 @@ RUN set -ex; \
         libldap2-dev \
         libfreetype6-dev \
         libjpeg-dev \
+        libonig-dev \
         zlib1g-dev \
         libc-client-dev \
         libkrb5-dev \
         libpng-dev \
         libpq-dev \
+        libzip-dev \
         netcat \
         \
         && apt-get -y autoclean; apt-get -y autoremove; \
@@ -28,7 +30,7 @@ RUN set -ex; \
 
 # Install PHP Plugins and Configure PHP imap plugin
 RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+        docker-php-ext-configure gd && \
         docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
         docker-php-ext-install -j5 \
         exif \

--- a/4.0/apache/Dockerfile
+++ b/4.0/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-apache
+FROM php:7.4-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.3.23+201026'
 ARG sha256_checksum='c78c0d821b1be9f522da3d6fda13910db27efb4bf32fc903b7986bbd7e39a312'
@@ -12,11 +12,13 @@ RUN set -ex; \
         libldap2-dev \
         libfreetype6-dev \
         libjpeg-dev \
+        libonig-dev \
         zlib1g-dev \
         libc-client-dev \
         libkrb5-dev \
         libpng-dev \
         libpq-dev \
+        libzip-dev \
         netcat \
         curl \
         \
@@ -29,7 +31,7 @@ RUN set -ex; \
 
 # Install PHP Plugins and Configure PHP imap plugin
 RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+        docker-php-ext-configure gd && \
         docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
         docker-php-ext-install -j5 \
         exif \

--- a/4.0/fpm-alpine/Dockerfile
+++ b/4.0/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm-alpine
+FROM php:7.4-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.3.23+201026'
 ARG sha256_checksum='c78c0d821b1be9f522da3d6fda13910db27efb4bf32fc903b7986bbd7e39a312'
@@ -8,15 +8,17 @@ RUN set -ex; \
         apk add --no-cache --virtual .build-deps \
         freetype-dev \
         libpng-dev \
+        libzip-dev \
         libjpeg-turbo-dev \
         openldap-dev \
+        oniguruma-dev \
         imap-dev \
         postgresql-dev && \
         apk add --no-cache netcat-openbsd bash
 
 # Install PHP Plugins
 RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr ; \
+        docker-php-ext-configure gd && \
         docker-php-ext-configure imap --with-imap-ssl && \
         docker-php-ext-install \
         exif \

--- a/4.0/fpm/Dockerfile
+++ b/4.0/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.4-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.3.23+201026'
 ARG sha256_checksum='c78c0d821b1be9f522da3d6fda13910db27efb4bf32fc903b7986bbd7e39a312'
@@ -12,11 +12,13 @@ RUN set -ex; \
         libldap2-dev \
         libfreetype6-dev \
         libjpeg-dev \
+        libonig-dev \
         zlib1g-dev \
         libc-client-dev \
         libkrb5-dev \
         libpng-dev \
         libpq-dev \
+        libzip-dev \
         netcat \
         \
         && apt-get -y autoclean; apt-get -y autoremove; \
@@ -28,7 +30,7 @@ RUN set -ex; \
 
 # Install PHP Plugins and Configure PHP imap plugin
 RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr; \
+        docker-php-ext-configure gd && \
         docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
         docker-php-ext-install -j5 \
         exif \


### PR DESCRIPTION
Since the PHP 7.2 support is going to end soon (30 Nov 2020) we'll update to PHP 7.4

PHP 7.4 is supported until 2022 and it is also recommended by the LimeSurvey Devs

> Minimum PHP 7.0 or later; however, we recommend PHP 7.4
> https://manual.limesurvey.org/Installation_-_LimeSurvey_CE#General

This makes #43 obsolete