### PR TITLE
Use docker volumes for postgres database

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,8 +22,10 @@ services:
     depends_on:
       - db
   db:
-    image: postgres:9.6-alpine
+    image: postgres:10-alpine
     restart: always
+    volumes:
+      - db-data:/var/lib/postgresql
     environment:
       - POSTGRES_USER=limesurvey
       - POSTGRES_DB=limesurvey
@@ -31,3 +33,4 @@ services:
 
 volumes:
   limesurvey:
+  db-data:

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -20,7 +20,12 @@ services:
       - "ADMIN_PASSWORD=foobar"
   lime-db:
     image: postgres:10
+    volumes:
+      - db-data:/var/lib/postgresql
     environment:
       - "POSTGRES_USER=limesurvey"
       - "POSTGRES_DB=limesurvey"
       - "POSTGRES_PASSWORD=secret"
+
+volumes:
+  db-data:


### PR DESCRIPTION
Hello @martialblog. Thanks for maintaining this repo :heart: 

I made some improvements to the docker-compose files so that the data saved in postgres are kept in volumes. Also updated from postgres 9.6 to 10 in `docker-compose.example.yml` to use the same version as in `docker-compose.pgsql.yml`