### PR TITLE
Add zlib package to fix #57

### DIFF
--- a/4.0/apache/Dockerfile
+++ b/4.0/apache/Dockerfile
@@ -23,8 +23,9 @@ RUN set -ex; \
         libsodium-dev \
         netcat \
         curl \
+        zlib1g-dev \
         \
-        && apt-get -y autoclean; apt-get -y autoremove; \
+        && apt-get -y autoclean; \
         rm -rf /var/lib/apt/lists/*
 
 # Link LDAP library for PHP ldap extension


### PR DESCRIPTION
Adds zlib package as suggested [here](https://github.com/docker-library/php/issues/61) to fix #57

I also had to remove `apt-get autoremove` because otherwise the package would be removed again immediately.