### PR TITLE
Customize Apache listen port

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# force LF in entrypoint.sh
+entrypoint.sh text eol=lf

--- a/3.0/apache/entrypoint.sh
+++ b/3.0/apache/entrypoint.sh
@@ -36,7 +36,7 @@ if [ -z "$ADMIN_PASSWORD" ]; then
 fi
 
 if [ "$LISTEN_PORT" != "80" ]; then
-    echo "Info: Customzizing Apache Listen port to $LISTEN_PORT"
+    echo "Info: Customizing Apache Listen port to $LISTEN_PORT"
     sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 

--- a/3.0/apache/entrypoint.sh
+++ b/3.0/apache/entrypoint.sh
@@ -23,6 +23,8 @@ URL_FORMAT=${URL_FORMAT:-'path'}
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
 
+LISTEN_PORT=${LISTEN_PORT:-"80"}
+
 if [ -z "$DB_PASSWORD" ]; then
     echo >&2 'Error: Missing DB_PASSWORD'
     exit 1
@@ -31,6 +33,11 @@ fi
 if [ -z "$ADMIN_PASSWORD" ]; then
     echo >&2 'Error: Missing ADMIN_PASSWORD'
     exit 1
+fi
+
+if [ "$LISTEN_PORT" != "80" ]; then
+    echo "Info: Customzizing Apache Listen port to $LISTEN_PORT"
+    sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 
 # Check if database is available

--- a/4.0/apache/entrypoint.sh
+++ b/4.0/apache/entrypoint.sh
@@ -27,6 +27,8 @@ URL_FORMAT=${URL_FORMAT:-'path'}
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
 
+LISTEN_PORT=${LISTEN_PORT:-"80"}
+
 if [ -z "$DB_PASSWORD" ]; then
     echo >&2 'Error: Missing DB_PASSWORD'
     exit 1
@@ -35,6 +37,11 @@ fi
 if [ -z "$ADMIN_PASSWORD" ]; then
     echo >&2 'Error: Missing ADMIN_PASSWORD'
     exit 1
+fi
+
+if [ "$LISTEN_PORT" != "80" ]; then
+    echo "Info: Customzizing Apache Listen port to $LISTEN_PORT"
+    sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 
 # Check if database is available

--- a/4.0/apache/entrypoint.sh
+++ b/4.0/apache/entrypoint.sh
@@ -40,7 +40,7 @@ if [ -z "$ADMIN_PASSWORD" ]; then
 fi
 
 if [ "$LISTEN_PORT" != "80" ]; then
-    echo "Info: Customzizing Apache Listen port to $LISTEN_PORT"
+    echo "Info: Customizing Apache Listen port to $LISTEN_PORT"
     sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For further details on the settings see: https://manual.limesurvey.org/Data_encr
 | ENCRYPT_KEYPAIR  | Data encryption keypair                  |
 | ENCRYPT_PUBLIC_KEY | Data encryption public key             |
 | ENCRYPT_SECRET_KEY | Data encryption secret key             |
-| LISTEN_PORT     | Apache: Listen port                       |
+| LISTEN_PORT     | Apache: Listen port. Default: 80          |
 
 For further details on the settings see: https://manual.limesurvey.org/Optional_settings#Advanced_Path_Settings
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To change to Apache Webserver configuration, mount a Volume into the Container a
 
 See the example configuration provided.
 
+If you want to run Apache on a non-privileged port inside the container, just specify a environment variable `LISTEN_PORT` (e.g. `LISTEN_PORT=8080`).
+
 # Using the fpm Image
 
 To use the fpm image, you need an additional web server that can proxy http-request to the fpm-port of the container. See *docker-compose.fpm.yml* for example.
@@ -112,6 +114,7 @@ For further details on the settings see: https://manual.limesurvey.org/Data_encr
 | ENCRYPT_KEYPAIR  | Data encryption keypair                  |
 | ENCRYPT_PUBLIC_KEY | Data encryption public key             |
 | ENCRYPT_SECRET_KEY | Data encryption secret key             |
+| LISTEN_PORT     | Apache: Listen port                       |
 
 For further details on the settings see: https://manual.limesurvey.org/Optional_settings#Advanced_Path_Settings
 


### PR DESCRIPTION
Some container orchestrators do not allow containers to use privileged ports (< 1024) by default, for example [OpenShift](https://docs.openshift.com/container-platform/4.7/openshift_images/create-images.html#images-create-guide-openshift_create-images).
Unfortunately, Apache uses 80 by default and changing the port requires modifying the Apache configuration files.

At my company we are using your wondeful image, but customized it to alter the Apache listen port (`Listen` and `VirtualHost` directives), and we are wondering, if we could bring that change back upstream.
