### PR TITLE
Fix Apache LISTEN_PORT "sed" command to look for whole "Listen" command

### DIFF
--- a/3.0/apache/entrypoint.sh
+++ b/3.0/apache/entrypoint.sh
@@ -37,7 +37,7 @@ fi
 
 if [ "$LISTEN_PORT" != "80" ]; then
     echo "Info: Customizing Apache Listen port to $LISTEN_PORT"
-    sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
+    sed -i "s/Listen 80\$/Listen $LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 
 # Check if database is available

--- a/4.0/apache/entrypoint.sh
+++ b/4.0/apache/entrypoint.sh
@@ -41,7 +41,7 @@ fi
 
 if [ "$LISTEN_PORT" != "80" ]; then
     echo "Info: Customizing Apache Listen port to $LISTEN_PORT"
-    sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
+    sed -i "s/Listen 80\$/Listen $LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 
 # Check if database is available

--- a/5.0/apache/entrypoint.sh
+++ b/5.0/apache/entrypoint.sh
@@ -42,7 +42,7 @@ fi
 
 if [ "$LISTEN_PORT" != "80" ]; then
     echo "Info: Customizing Apache Listen port to $LISTEN_PORT"
-    sed -i "s/80/$LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
+    sed -i "s/Listen 80\$/Listen $LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
 fi
 
 # Check if database is available


### PR DESCRIPTION
Otherwise, if the replaced port number contains "80" (for example, "8080",
as is now the default), it is replaced over and over on each activation