### PR TITLE
Add variable for setting table session

### DIFF
--- a/3.0/apache/entrypoint.sh
+++ b/3.0/apache/entrypoint.sh
@@ -19,6 +19,8 @@ ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
 
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
@@ -89,10 +91,15 @@ return array(
       'charset' => '$DB_CHARSET',
       'tablePrefix' => '$DB_TABLE_PREFIX',
     ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
     'urlManager' => array(
       'urlFormat' => '$URL_FORMAT',
       'rules' => array(),
-      'showScriptName' => true,
+      'showScriptName' => $SHOW_SCRIPT_NAME,
     ),
     'request' => array(
       'baseUrl' => '$BASE_URL',
@@ -109,6 +116,12 @@ EOF
 
 fi
 
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
+fi
 
 # Check if LimeSurvey database is provisioned
 echo 'Info: Check if database already provisioned. Nevermind the Stack trace.'

--- a/3.0/fpm-alpine/entrypoint.sh
+++ b/3.0/fpm-alpine/entrypoint.sh
@@ -19,6 +19,8 @@ ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
 
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
@@ -82,10 +84,15 @@ return array(
       'charset' => '$DB_CHARSET',
       'tablePrefix' => '$DB_TABLE_PREFIX',
     ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
     'urlManager' => array(
       'urlFormat' => '$URL_FORMAT',
       'rules' => array(),
-      'showScriptName' => true,
+      'showScriptName' => $SHOW_SCRIPT_NAME,
     ),
     'request' => array(
       'baseUrl' => '$BASE_URL',
@@ -102,6 +109,12 @@ EOF
 
 fi
 
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
+fi
 
 # Check if LimeSurvey database is provisioned
 echo 'Info: Check if database already provisioned. Nevermind the Stack trace.'

--- a/3.0/fpm/entrypoint.sh
+++ b/3.0/fpm/entrypoint.sh
@@ -19,6 +19,8 @@ ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
 
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
@@ -82,10 +84,15 @@ return array(
       'charset' => '$DB_CHARSET',
       'tablePrefix' => '$DB_TABLE_PREFIX',
     ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
     'urlManager' => array(
       'urlFormat' => '$URL_FORMAT',
       'rules' => array(),
-      'showScriptName' => true,
+      'showScriptName' => $SHOW_SCRIPT_NAME,
     ),
     'request' => array(
       'baseUrl' => '$BASE_URL',
@@ -102,6 +109,12 @@ EOF
 
 fi
 
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
+fi
 
 # Check if LimeSurvey database is provisioned
 echo 'Info: Check if database already provisioned. Nevermind the Stack trace.'

--- a/5.0/apache/entrypoint.sh
+++ b/5.0/apache/entrypoint.sh
@@ -24,6 +24,7 @@ BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
 
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
@@ -94,6 +95,11 @@ return array(
       'charset' => '$DB_CHARSET',
       'tablePrefix' => '$DB_TABLE_PREFIX',
     ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
     'urlManager' => array(
       'urlFormat' => '$URL_FORMAT',
       'rules' => array(),
@@ -112,6 +118,13 @@ return array(
 
 EOF
 
+fi
+
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
 fi
 
 # Check if security config already provisioned

--- a/5.0/fpm-alpine/entrypoint.sh
+++ b/5.0/fpm-alpine/entrypoint.sh
@@ -24,6 +24,7 @@ BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
 
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
@@ -87,6 +88,11 @@ return array(
       'charset' => '$DB_CHARSET',
       'tablePrefix' => '$DB_TABLE_PREFIX',
     ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
     'urlManager' => array(
       'urlFormat' => '$URL_FORMAT',
       'rules' => array(),
@@ -105,6 +111,13 @@ return array(
 
 EOF
 
+fi
+
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
 fi
 
 # Check if security config already provisioned

--- a/5.0/fpm/entrypoint.sh
+++ b/5.0/fpm/entrypoint.sh
@@ -24,6 +24,7 @@ BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
 
 DEBUG=${DEBUG:-0}
 DEBUG_SQL=${DEBUG_SQL:-0}
@@ -87,6 +88,11 @@ return array(
       'charset' => '$DB_CHARSET',
       'tablePrefix' => '$DB_TABLE_PREFIX',
     ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
     'urlManager' => array(
       'urlFormat' => '$URL_FORMAT',
       'rules' => array(),
@@ -105,6 +111,13 @@ return array(
 
 EOF
 
+fi
+
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
 fi
 
 # Check if security config already provisioned

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ For further details on the settings see: https://manual.limesurvey.org/Data_encr
 | PUBLIC_URL      | Public URL for public scripts             |
 | BASE_URL        | Application Base URL                      |
 | URL_FORMAT      | URL Format. path or get                   |
+| TABLE_SESSION   | Enable table sessions (true)              |
 | SHOW_SCRIPT_NAME | Script name in URL (true|false). Default: true |
 | DEBUG           | Debug level (0, 1, 2). Default: 0         |
 | DEBUG_SQL       | SQL Debug level (0, 1, 2). Default 0      |


### PR DESCRIPTION
In order to scale LimeSurvey horizontally we need the sessions to be at a central point. LS is able to store sessions in its database, this PR adds a variable to enable this setting.

I wanted to add this to a new config file named `session.php`, but I'm not sure if and how that would work. (I'm no PHP dev)

So, I had to refactor the creation of the config.php a bit... maybe there is a better way.

Fixes #75 

PS: Also the SHOW_SCRIPT_NAME variable was missing in LS 3.* - fixed now