### PR TITLE
Bug fixes for certbot-nginx config.

### DIFF
--- a/nginx-certbot/entrypoint.sh
+++ b/nginx-certbot/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 cert_path=/etc/letsencrypt/live/$(echo "$HOSTNAMES" | awk '{print $1}')
-mkdir -p cert_path
+mkdir -p $cert_path
 
 # if there is no certificate yet, get one
 email="--email $CERT_EMAIL"
@@ -19,7 +19,7 @@ then
     echo "Getting new certificate..."
     /usr/bin/curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > /etc/letsencrypt/options-ssl-nginx.conf
     /usr/bin/curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > /etc/letsencrypt/ssl-dhparams.pem
-    /usr/bin/certbot certonly --standalone "$names" --agree-tos "$email"
+    /usr/bin/certbot certonly --standalone $names --agree-tos "$email"
 fi
 
 nginx -g "daemon off;"


### PR DESCRIPTION
- added missing $ for variable
- removed ``"``` which lead to cert bot incorrrectly reading "-d example.com" as a whole as an argument, and throwing an error