### PR TITLE
Change origin port for 3.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - lime-db
     ports:
-      - "8080:8080"
+      - "80:8080"
     environment:
       - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"


### PR DESCRIPTION
In case of the LTS, the port must be 80:8080 because the apache is configured to run on port 80.