### PR TITLE
Update entrypoint to enable an empty table prefix

### DIFF
--- a/3.0/apache/entrypoint.sh
+++ b/3.0/apache/entrypoint.sh
@@ -89,7 +89,7 @@ return array(
       'username' => '$DB_USERNAME',
       'password' => '$DB_PASSWORD',
       'charset' => '$DB_CHARSET',
-      'tablePrefix' => '$DB_TABLE_PREFIX',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
     ),
     //'session' => array (
     //   'class' => 'application.core.web.DbHttpSession',

--- a/3.0/fpm-alpine/entrypoint.sh
+++ b/3.0/fpm-alpine/entrypoint.sh
@@ -82,7 +82,7 @@ return array(
       'username' => '$DB_USERNAME',
       'password' => '$DB_PASSWORD',
       'charset' => '$DB_CHARSET',
-      'tablePrefix' => '$DB_TABLE_PREFIX',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
     ),
     //'session' => array (
     //   'class' => 'application.core.web.DbHttpSession',

--- a/3.0/fpm/entrypoint.sh
+++ b/3.0/fpm/entrypoint.sh
@@ -82,7 +82,7 @@ return array(
       'username' => '$DB_USERNAME',
       'password' => '$DB_PASSWORD',
       'charset' => '$DB_CHARSET',
-      'tablePrefix' => '$DB_TABLE_PREFIX',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
     ),
     //'session' => array (
     //   'class' => 'application.core.web.DbHttpSession',

--- a/5.0/apache/entrypoint.sh
+++ b/5.0/apache/entrypoint.sh
@@ -96,7 +96,7 @@ return array(
       'username' => '$DB_USERNAME',
       'password' => '$DB_PASSWORD',
       'charset' => '$DB_CHARSET',
-      'tablePrefix' => '$DB_TABLE_PREFIX',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
     ),
     //'session' => array (
     //   'class' => 'application.core.web.DbHttpSession',

--- a/5.0/fpm-alpine/entrypoint.sh
+++ b/5.0/fpm-alpine/entrypoint.sh
@@ -89,7 +89,7 @@ return array(
       'username' => '$DB_USERNAME',
       'password' => '$DB_PASSWORD',
       'charset' => '$DB_CHARSET',
-      'tablePrefix' => '$DB_TABLE_PREFIX',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
     ),
     //'session' => array (
     //   'class' => 'application.core.web.DbHttpSession',

--- a/5.0/fpm/entrypoint.sh
+++ b/5.0/fpm/entrypoint.sh
@@ -89,7 +89,7 @@ return array(
       'username' => '$DB_USERNAME',
       'password' => '$DB_PASSWORD',
       'charset' => '$DB_CHARSET',
-      'tablePrefix' => '$DB_TABLE_PREFIX',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
     ),
     //'session' => array (
     //   'class' => 'application.core.web.DbHttpSession',

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For further details on the settings see: https://manual.limesurvey.org/Data_encr
 | DB_PORT         | Database server port                      |
 | DB_SOCK         | Database unix socket instead of host/port |
 | DB_NAME         | Database name                             |
-| DB_TABLE_PREFIX | Database table prefix                     |
+| DB_TABLE_PREFIX | Database table prefix; set this to a single whitespace if you don't want a table prefix. |
 | DB_MYSQL_ENGINE | MySQL engine used for survey tables (values: MyISAM, InnoDB, default: MyISAM)       |
 | DB_USERNAME     | Database user                             |
 | DB_PASSWORD     | Database user's password                  |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"
       - "ADMIN_PASSWORD=foobar"
-      # Example: If you require an empty table prefix
+      # If you require an empty table prefix, use a space as the DB_TABLE_PREFIX
       # - "DB_TABLE_PREFIX= "
   lime-db:
     image: mysql:5.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - "DB_HOST=lime-db"
       - "DB_PASSWORD=secret"
       - "ADMIN_PASSWORD=foobar"
+      # Example: If you require an empty table prefix
+      # - "DB_TABLE_PREFIX= "
   lime-db:
     image: mysql:5.7
     environment:


### PR DESCRIPTION
 - Who are we to dictate a table prefix
 - Makes it easier to migrate existing databases that don't have a prefix

Fixes #88 