### PR TITLE
Add depends_on for nginx so it waits until the limesurvey app is ready

### DIFF
--- a/docker-compose.fpm.alpine.yml
+++ b/docker-compose.fpm.alpine.yml
@@ -20,6 +20,8 @@ services:
     image: nginx:alpine
     links:
       - limesurvey
+    depends_on:
+      - limesurvey
     ports:
       - "8080:80"
     volumes:


### PR DESCRIPTION
Depending on how the containers start up, nginx fails if it can't find the limesurvey app:
lime-web_1    | 2021/11/23 17:06:34 [emerg] 1#1: host not found in upstream "limesurvey" in /etc/nginx/nginx.conf:33
lime-web_1    | nginx: [emerg] host not found in upstream "limesurvey" in /etc/nginx/nginx.conf:33

By adding a depends_on in lime-web, it will wait for the limesurvey app to be ready to accept connections.