### PR TITLE
Extend example nginx.conf to include more protected paths

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -19,7 +19,7 @@ http {
         location / {
             try_files $uri /index.php?$args;
         }
-        location ~ ^/(protected|framework|themes/\w+/views) {
+        location ~ ^/(protected|application|framework|themes/\w+/views) {
             deny  all;
         }
         location ~ \.(js|css|png|jpg|gif|swf|ico|pdf|mov|fla|zip|rar)$ {


### PR DESCRIPTION
With this config files in application/ are not directly accessable.

See #101 