### PR TITLE
Fix image tag generation

### DIFF
--- a/.github/workflows/build-latest-container-images.yaml
+++ b/.github/workflows/build-latest-container-images.yaml
@@ -49,10 +49,11 @@ jobs:
           images: |
             docker.io/martialblog/limesurvey
           tags: |
-            type=semver,pattern={{raw}},suffix=-apache
-            type=semver,pattern={{major}},suffix=-apache
+            type=match,pattern=(.+),group=1
+            type=match,pattern=^(\d+),group=1
           flavor: |
             latest=false
+            suffix=-apache
       - name: 'Build and push latest Apache container images'
         uses: docker/build-push-action@v2
         with:
@@ -68,8 +69,11 @@ jobs:
           images: |
             docker.io/martialblog/limesurvey
           tags: |
-            type=semver,pattern={{version}},suffix=-fpm
-            type=semver,pattern={{major}},suffix=-fpm
+            type=match,pattern=(.+),group=1
+            type=match,pattern=^(\d+),group=1
+          flavor: |
+            latest=false
+            suffix=-fpm
       - name: 'Build and push latest fpm container images'
         uses: docker/build-push-action@v2
         with:
@@ -85,8 +89,11 @@ jobs:
           images: |
             docker.io/martialblog/limesurvey
           tags: |
-            type=semver,pattern={{version}},suffix=-fpm-alpine
-            type=semver,pattern={{major}},suffix=-fpm-alpine
+            type=match,pattern=(.+),group=1
+            type=match,pattern=^(\d+),group=1
+          flavor: |
+            latest=false
+            suffix=-fpm-alpine
       - name: 'Build and push latest fpm-alpine container images'
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-lts-container-images.yaml
+++ b/.github/workflows/build-lts-container-images.yaml
@@ -49,10 +49,11 @@ jobs:
           images: |
             docker.io/martialblog/limesurvey
           tags: |
-            type=semver,pattern={{raw}},suffix=-apache
-            type=semver,pattern={{major}},suffix=-apache
+            type=match,pattern=(.+),group=1
+            type=match,pattern=^(\d+),group=1
           flavor: |
             latest=false
+            suffix=-apache
       - name: 'Build and push LTS apache container images'
         uses: docker/build-push-action@v2
         with:
@@ -68,8 +69,11 @@ jobs:
           images: |
             docker.io/martialblog/limesurvey
           tags: |
-            type=semver,pattern={{version}},suffix=-fpm
-            type=semver,pattern={{major}},suffix=-fpm
+            type=match,pattern=(.+),group=1
+            type=match,pattern=^(\d+),group=1
+          flavor: |
+            latest=false
+            suffix=-fpm
       - name: 'Build and push LTS fpm container images'
         uses: docker/build-push-action@v2
         with:
@@ -85,8 +89,11 @@ jobs:
           images: |
             docker.io/martialblog/limesurvey
           tags: |
-            type=semver,pattern={{version}},suffix=-fpm-alpine
-            type=semver,pattern={{major}},suffix=-fpm-alpine
+            type=match,pattern=(.+),group=1
+            type=match,pattern=^(\d+),group=1
+          flavor: |
+            latest=false
+            suffix=-fpm-alpine
       - name: 'Build and push LTS fpm-alpine container images'
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
Previously, only the immutable tags would get generated (i.e.
`5.1.2-1234`), but not the rolling tags (`5-apache`), due to a
limitation of the docker metadata action.
Thus, now we use manual regex matching instead.
See the linked issue for details.

Fixes https://github.com/martialblog/docker-limesurvey/issues/105