### PR TITLE
Add a Traefik example with subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ For further details on the settings see: https://manual.limesurvey.org/Data_encr
 
 ## Traefik example
 
+**Hint**: if you want to deploy LimeSurvey on a sub-path (e.g. https://example.com/limesurvey) you have to set the BASE_URL and adjust the Containers Webservers. See the docker-compose Traefik example in the repository.
+
 ```
 # BASE_URL = /limesurvey
 "traefik.http.routers.limesurvey.rule=PathPrefix(`/limesurvey`)",

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,46 @@
+version: "3.0"
+services:
+  limesurvey:
+    build:
+      context: 5.0/apache/
+      dockerfile: Dockerfile
+    labels:
+      traefik.enable: 'true'
+      traefik.http.routers.limesurvey-http-router.entrypoints: "http"
+      traefik.http.routers.limesurvey-http-router.rule: "PathPrefix(`/limesurvey`)"
+      traefik.http.services.limesurvey-service.loadbalancer.server.port: "8080"
+    links:
+      - lime-db
+    depends_on:
+      - lime-db
+    volumes:
+      # Unfortunately the StripPrefix Function in Traefik won't work;
+      # Meaning, we will have to set 'Alias /limesurvey "/var/www/html"' in the Apache Config
+      - "./examples/apache-example.conf:/etc/apache2/sites-available/000-default.conf:ro"
+    environment:
+      - "DB_HOST=lime-db"
+      - "DB_PASSWORD=secret"
+      - "ADMIN_PASSWORD=foobar"
+      - "PUBLIC_URL=http://localhost:8888/limesurvey"
+      - "BASE_URL=http://localhost:8888/limesurvey"
+  traefik:
+    image: "traefik:v2.5"
+    container_name: "traefik"
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.http.address=:8888"
+    ports:
+      - "8888:8888"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+  lime-db:
+    image: mysql:5.7
+    environment:
+      - "MYSQL_USER=limesurvey"
+      - "MYSQL_DATABASE=limesurvey"
+      - "MYSQL_PASSWORD=secret"
+      - "MYSQL_ROOT_PASSWORD=secret"
+

--- a/examples/apache-example.conf
+++ b/examples/apache-example.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:8080>
 	ServerAdmin foo@bar.com
 	DocumentRoot /var/www/html
-        Alias /lime "/var/www/html"
+        Alias /limesurvey "/var/www/html"
 
         <Directory />
                 Options FollowSymLinks


### PR DESCRIPTION
While the proxy is usually able to strip the prefix before routing to the Container, this won't work (for some reason). 

Users will have to pass a webserver Configuration with an Alias, as shown in this example. 

Fixes #106  
Fixes #42 