### PR TITLE
Enable :latest Tag for Apache Image

### DIFF
--- a/.github/workflows/build-latest-container-images.yaml
+++ b/.github/workflows/build-latest-container-images.yaml
@@ -52,7 +52,7 @@ jobs:
             type=match,pattern=(.+),group=1
             type=match,pattern=^(\d+),group=1
           flavor: |
-            latest=false
+            latest=true
             suffix=-apache
       - name: 'Build and push latest Apache container images'
         uses: docker/build-push-action@v2


### PR DESCRIPTION
It shouldn't be used, but can be. Who are we to impede users from living on the edge?

Fixes #114 