### PR TITLE
Upgrade to 5.3.2+220302

### DIFF
--- a/5.0/apache/Dockerfile
+++ b/5.0/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
-ARG version='5.3.1+220301'
-ARG sha256_checksum='8fc398380bf65b7f35128cebb29175ab1c3678002da776b35545682b0a00384b'
+ARG version='5.3.2+220302'
+ARG sha256_checksum='364f48a04124f26eab993d01fd2937344b1ac50f138ef0fb7c94693c66b1e154'
 ARG USER=www-data
 ARG LISTEN_PORT=8080
 

--- a/5.0/fpm-alpine/Dockerfile
+++ b/5.0/fpm-alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
-ARG version='5.3.1+220301'
-ARG sha256_checksum='8fc398380bf65b7f35128cebb29175ab1c3678002da776b35545682b0a00384b'
+ARG version='5.3.2+220302'
+ARG sha256_checksum='364f48a04124f26eab993d01fd2937344b1ac50f138ef0fb7c94693c66b1e154'
 ARG USER=www-data
 
 # Install OS dependencies

--- a/5.0/fpm/Dockerfile
+++ b/5.0/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
-ARG version='5.3.1+220301'
-ARG sha256_checksum='8fc398380bf65b7f35128cebb29175ab1c3678002da776b35545682b0a00384b'
+ARG version='5.3.2+220302'
+ARG sha256_checksum='364f48a04124f26eab993d01fd2937344b1ac50f138ef0fb7c94693c66b1e154'
 ARG USER=www-data
 
 # Install OS dependencies


### PR DESCRIPTION
Hi @martialblog!

Thanks for creating and maintaining these images, which I use among other things to test https://github.com/edgarrmondragon/citric.

Version of [`5.3.2+220302`](https://github.com/LimeSurvey/LimeSurvey/releases/tag/5.3.2%2B220302) was released a few days ago so I figured I'd try to contribute the update here.

This is how I computed the shasum:

```console
$ shasum -a 256 ~/Downloads/LimeSurvey-5.3.1-220301.tar.gz
8fc398380bf65b7f35128cebb29175ab1c3678002da776b35545682b0a00384b  /Users/edgarramirez/Downloads/LimeSurvey-5.3.1-220301.tar.gz

$ shasum -a 256 ~/Downloads/LimeSurvey-5.3.2-220302.tar.gz
364f48a04124f26eab993d01fd2937344b1ac50f138ef0fb7c94693c66b1e154  /Users/edgarramirez/Downloads/LimeSurvey-5.3.2-220302.tar.gz
```

If you don't mind and you accept this contribution I can also send the next version update already out there (`5.3.3+220307`).
