### PR TITLE
feat: Add a 'repository' build argument

### DIFF
--- a/3.0/apache/Dockerfile
+++ b/3.0/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
-ARG version='3.28.12+220524'
-ARG sha256_checksum='18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def'
+ARG version="3.28.12+220524"
+ARG sha256_checksum="18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=root
 ARG LISTEN_PORT=80

--- a/3.0/apache/Dockerfile
+++ b/3.0/apache/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.28.11+220517'
 ARG sha256_checksum='8a36643b4341dd5095ee484da677a94a4bff25ee2ed6567136062bd0c7af4226'
+ARG repository='LimeSurvey/LimeSurvey'
 ARG USER=root
 ARG LISTEN_PORT=80
 
@@ -65,9 +66,9 @@ RUN a2enmod headers rewrite remoteip; \
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/3.0/apache/Dockerfile
+++ b/3.0/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.28.12+220524'
 ARG sha256_checksum='18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=root
 ARG LISTEN_PORT=80
 
@@ -68,7 +68,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/3.0/fpm-alpine/Dockerfile
+++ b/3.0/fpm-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.28.12+220524'
 ARG sha256_checksum='18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies
 RUN set -ex; \
@@ -38,7 +38,7 @@ RUN set -ex; \
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/3.0/fpm-alpine/Dockerfile
+++ b/3.0/fpm-alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
-ARG version='3.28.12+220524'
-ARG sha256_checksum='18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def'
+ARG version="3.28.12+220524"
+ARG sha256_checksum="18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies

--- a/3.0/fpm-alpine/Dockerfile
+++ b/3.0/fpm-alpine/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.28.11+220517'
 ARG sha256_checksum='8a36643b4341dd5095ee484da677a94a4bff25ee2ed6567136062bd0c7af4226'
+ARG repository='LimeSurvey/LimeSurvey'
 
 # Install OS dependencies
 RUN set -ex; \
@@ -35,9 +36,9 @@ RUN set -ex; \
         tidy \
         zip
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/3.0/fpm/Dockerfile
+++ b/3.0/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
-ARG version='3.28.12+220524'
-ARG sha256_checksum='18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def'
+ARG version="3.28.12+220524"
+ARG sha256_checksum="18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies

--- a/3.0/fpm/Dockerfile
+++ b/3.0/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.28.12+220524'
 ARG sha256_checksum='18437545fc0b86900663d494508284a1a5340e6db4fc9eb7a598fb8304dd8def'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies
 RUN set -ex; \
@@ -53,7 +53,7 @@ ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/3.0/fpm/Dockerfile
+++ b/3.0/fpm/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='3.28.11+220517'
 ARG sha256_checksum='8a36643b4341dd5095ee484da677a94a4bff25ee2ed6567136062bd0c7af4226'
+ARG repository='LimeSurvey/LimeSurvey'
 
 # Install OS dependencies
 RUN set -ex; \
@@ -50,9 +51,9 @@ RUN set -ex; \
 
 ENV LIMESURVEY_VERSION=$version
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/4.0/apache/Dockerfile
+++ b/4.0/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
-ARG version='4.6.3+210518'
-ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
+ARG version="4.6.3+210518"
+ARG sha256_checksum="3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=root
 ARG LISTEN_PORT=80

--- a/4.0/apache/Dockerfile
+++ b/4.0/apache/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.6.3+210518'
 ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
+ARG repository='LimeSurvey/LimeSurvey'
 ARG USER=root
 ARG LISTEN_PORT=80
 
@@ -66,9 +67,9 @@ RUN a2enmod headers rewrite remoteip; \
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/4.0/apache/Dockerfile
+++ b/4.0/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.6.3+210518'
 ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=root
 ARG LISTEN_PORT=80
 
@@ -69,7 +69,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/4.0/fpm-alpine/Dockerfile
+++ b/4.0/fpm-alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
-ARG version='4.6.3+210518'
-ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
+ARG version="4.6.3+210518"
+ARG sha256_checksum="3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies

--- a/4.0/fpm-alpine/Dockerfile
+++ b/4.0/fpm-alpine/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.6.3+210518'
 ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
+ARG repository='LimeSurvey/LimeSurvey'
 
 # Install OS dependencies
 RUN set -ex; \
@@ -36,9 +37,9 @@ RUN set -ex; \
         tidy \
         zip
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/4.0/fpm-alpine/Dockerfile
+++ b/4.0/fpm-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.6.3+210518'
 ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies
 RUN set -ex; \
@@ -39,7 +39,7 @@ RUN set -ex; \
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/4.0/fpm/Dockerfile
+++ b/4.0/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
-ARG version='4.6.3+210518'
-ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
+ARG version="4.6.3+210518"
+ARG sha256_checksum="3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies

--- a/4.0/fpm/Dockerfile
+++ b/4.0/fpm/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.6.3+210518'
 ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
+ARG repository='LimeSurvey/LimeSurvey'
 
 # Install OS dependencies
 RUN set -ex; \
@@ -50,9 +51,9 @@ RUN set -ex; \
 
 ENV LIMESURVEY_VERSION=$version
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/4.0/fpm/Dockerfile
+++ b/4.0/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='4.6.3+210518'
 ARG sha256_checksum='3c59afc13d0cf974c465c5f851cb8837117518e94031f5e3a28ba468ad734ce2'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies
 RUN set -ex; \
@@ -53,7 +53,7 @@ ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/5.0/apache/Dockerfile
+++ b/5.0/apache/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='5.3.17+220525'
 ARG sha256_checksum='fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=www-data
 ARG LISTEN_PORT=8080
 
@@ -69,7 +69,7 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/5.0/apache/Dockerfile
+++ b/5.0/apache/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
 ARG version='5.3.16+220523'
 ARG sha256_checksum='146447308ff09a6f4ed9c3fff65422d2f03d38ce1aba8c314eaf6d79366ef2d7'
+ARG repository='LimeSurvey/LimeSurvey'
 ARG USER=www-data
 ARG LISTEN_PORT=8080
 
@@ -66,9 +67,9 @@ RUN a2enmod headers rewrite remoteip; \
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/5.0/apache/Dockerfile
+++ b/5.0/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
-ARG version='5.3.17+220525'
-ARG sha256_checksum='fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8'
+ARG version="5.3.17+220525"
+ARG sha256_checksum="fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=www-data
 ARG LISTEN_PORT=8080

--- a/5.0/fpm-alpine/Dockerfile
+++ b/5.0/fpm-alpine/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
-ARG version='5.3.17+220525'
-ARG sha256_checksum='fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8'
+ARG version="5.3.17+220525"
+ARG sha256_checksum="fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=www-data
 

--- a/5.0/fpm-alpine/Dockerfile
+++ b/5.0/fpm-alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='5.3.17+220525'
 ARG sha256_checksum='fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=www-data
 
 # Install OS dependencies
@@ -40,7 +40,7 @@ RUN set -ex; \
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/5.0/fpm-alpine/Dockerfile
+++ b/5.0/fpm-alpine/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 ARG version='5.3.16+220523'
 ARG sha256_checksum='146447308ff09a6f4ed9c3fff65422d2f03d38ce1aba8c314eaf6d79366ef2d7'
+ARG repository='LimeSurvey/LimeSurvey'
 ARG USER=www-data
 
 # Install OS dependencies
@@ -37,9 +38,9 @@ RUN set -ex; \
         tidy \
         zip
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/5.0/fpm/Dockerfile
+++ b/5.0/fpm/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='5.3.17+220525'
 ARG sha256_checksum='fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8'
-ARG repository='LimeSurvey/LimeSurvey'
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=www-data
 
 # Install OS dependencies
@@ -54,7 +54,7 @@ ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \

--- a/5.0/fpm/Dockerfile
+++ b/5.0/fpm/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
-ARG version='5.3.17+220525'
-ARG sha256_checksum='fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8'
+ARG version="5.3.17+220525"
+ARG sha256_checksum="fe94c4d9dc11bf0742855c70ce496be48e5556365f403fe9fcb433ed0b0494a8"
 ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ARG USER=www-data
 

--- a/5.0/fpm/Dockerfile
+++ b/5.0/fpm/Dockerfile
@@ -2,6 +2,7 @@ FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
 ARG version='5.3.16+220523'
 ARG sha256_checksum='146447308ff09a6f4ed9c3fff65422d2f03d38ce1aba8c314eaf6d79366ef2d7'
+ARG repository='LimeSurvey/LimeSurvey'
 ARG USER=www-data
 
 # Install OS dependencies
@@ -51,9 +52,9 @@ RUN set -ex; \
 
 ENV LIMESURVEY_VERSION=$version
 
-# Download, unzip and chmod LimeSurvey from official GitHub repository
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \
-        curl -sSL "https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
+        curl -sSL "https://github.com/${repository}/archive/${version}.tar.gz" --output /tmp/limesurvey.tar.gz && \
         echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
         \
         tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \


### PR DESCRIPTION
Allows building the images from LimeSurvey forks.

For example:

```bash
docker build \
  --build-arg version=18158-delete_question-findAllByAttributes \
  --build-arg sha256_checksum=0f5d94dd66eec828b10c188bd2e99cba4dcad0727f8345b7844e47be0d7a71ec \
  --build-arg repository=edgarrmondragon/LimeSurvey \
   -t ls-test \
  'https://github.com/edgarrmondragon/docker-limesurvey#feat-repository-arg:5.0'
```