### PR TITLE
Move `ARG` instructions right before where they are used

### DIFF
--- a/3.0/apache/Dockerfile
+++ b/3.0/apache/Dockerfile
@@ -1,10 +1,5 @@
 FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
-ARG version="3.28.13+220531"
-ARG sha256_checksum="57273ebd94c54e1501496451137f2d1cf205551c7dd0eebcb42b6aebeec6e1a7"
-ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
-ARG USER=root
-ARG LISTEN_PORT=80
 
 # Install OS dependencies
 RUN set -ex; \
@@ -51,8 +46,6 @@ RUN set -ex; \
         tidy \
         zip
 
-ENV LIMESURVEY_VERSION=$version
-
 # Apache configuration
 RUN a2enmod headers rewrite remoteip; \
         {\
@@ -65,6 +58,13 @@ RUN a2enmod headers rewrite remoteip; \
 
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+ARG version="3.28.13+220531"
+ARG sha256_checksum="57273ebd94c54e1501496451137f2d1cf205551c7dd0eebcb42b6aebeec6e1a7"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=root
+ARG LISTEN_PORT=80
+ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \

--- a/3.0/fpm-alpine/Dockerfile
+++ b/3.0/fpm-alpine/Dockerfile
@@ -1,8 +1,5 @@
 FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
-ARG version="3.28.13+220531"
-ARG sha256_checksum="57273ebd94c54e1501496451137f2d1cf205551c7dd0eebcb42b6aebeec6e1a7"
-ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies
 RUN set -ex; \
@@ -35,6 +32,11 @@ RUN set -ex; \
         sodium \
         tidy \
         zip
+
+ARG version="3.28.13+220531"
+ARG sha256_checksum="57273ebd94c54e1501496451137f2d1cf205551c7dd0eebcb42b6aebeec6e1a7"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \

--- a/3.0/fpm/Dockerfile
+++ b/3.0/fpm/Dockerfile
@@ -1,8 +1,5 @@
 FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
-ARG version="3.28.13+220531"
-ARG sha256_checksum="57273ebd94c54e1501496451137f2d1cf205551c7dd0eebcb42b6aebeec6e1a7"
-ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 
 # Install OS dependencies
 RUN set -ex; \
@@ -49,6 +46,9 @@ RUN set -ex; \
         tidy \
         zip
 
+ARG version="3.28.13+220531"
+ARG sha256_checksum="57273ebd94c54e1501496451137f2d1cf205551c7dd0eebcb42b6aebeec6e1a7"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
 ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 

--- a/5.0/apache/Dockerfile
+++ b/5.0/apache/Dockerfile
@@ -1,10 +1,5 @@
 FROM php:8.0-apache
 LABEL maintainer="markus@martialblog.de"
-ARG version="5.3.18+220530"
-ARG sha256_checksum="3b866045dcefd78dab39bcef186a8e4ca6408c08e4c43b636415e75610fa9434"
-ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
-ARG USER=www-data
-ARG LISTEN_PORT=8080
 
 # Install OS dependencies
 RUN set -ex; \
@@ -52,8 +47,6 @@ RUN set -ex; \
         tidy \
         zip
 
-ENV LIMESURVEY_VERSION=$version
-
 # Apache configuration
 RUN a2enmod headers rewrite remoteip; \
         {\
@@ -66,6 +59,13 @@ RUN a2enmod headers rewrite remoteip; \
 
 # Use the default production configuration
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+ARG version="5.3.18+220530"
+ARG sha256_checksum="3b866045dcefd78dab39bcef186a8e4ca6408c08e4c43b636415e75610fa9434"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=www-data
+ARG LISTEN_PORT=8080
+ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \

--- a/5.0/fpm-alpine/Dockerfile
+++ b/5.0/fpm-alpine/Dockerfile
@@ -1,9 +1,5 @@
 FROM php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
-ARG version="5.3.18+220530"
-ARG sha256_checksum="3b866045dcefd78dab39bcef186a8e4ca6408c08e4c43b636415e75610fa9434"
-ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
-ARG USER=www-data
 
 # Install OS dependencies
 RUN set -ex; \
@@ -37,6 +33,12 @@ RUN set -ex; \
         sodium \
         tidy \
         zip
+
+ARG version="5.3.18+220530"
+ARG sha256_checksum="3b866045dcefd78dab39bcef186a8e4ca6408c08e4c43b636415e75610fa9434"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=www-data
+ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 
 RUN set -ex; \

--- a/5.0/fpm/Dockerfile
+++ b/5.0/fpm/Dockerfile
@@ -1,9 +1,5 @@
 FROM php:8.0-fpm
 LABEL maintainer="markus@martialblog.de"
-ARG version="5.3.18+220530"
-ARG sha256_checksum="3b866045dcefd78dab39bcef186a8e4ca6408c08e4c43b636415e75610fa9434"
-ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
-ARG USER=www-data
 
 # Install OS dependencies
 RUN set -ex; \
@@ -50,6 +46,10 @@ RUN set -ex; \
         tidy \
         zip
 
+ARG version="5.3.18+220530"
+ARG sha256_checksum="3b866045dcefd78dab39bcef186a8e4ca6408c08e4c43b636415e75610fa9434"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=www-data
 ENV LIMESURVEY_VERSION=$version
 
 # Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository) 


### PR DESCRIPTION
Benefits:

- Re-builds are faster since they use the cache of the first `RUN` layer
- Earlier layers can be eventually templated (as in https://github.com/docker-library/postgres/blob/master/apply-templates.sh)