### PR TITLE
Update Repository for new 6.0 Release

### DIFF
--- a/.github/workflows/build-latest-container-images.yaml
+++ b/.github/workflows/build-latest-container-images.yaml
@@ -64,7 +64,7 @@ jobs:
             latest=true
             suffix=-apache
       - name: 'Build and push latest Apache container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 6.0/apache
           push: true
@@ -85,7 +85,7 @@ jobs:
             latest=false
             suffix=-fpm
       - name: 'Build and push latest fpm container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 6.0/fpm
           push: true
@@ -106,7 +106,7 @@ jobs:
             latest=false
             suffix=-fpm-alpine
       - name: 'Build and push latest fpm-alpine container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 6.0/fpm-alpine
           push: true

--- a/.github/workflows/build-latest-container-images.yaml
+++ b/.github/workflows/build-latest-container-images.yaml
@@ -15,7 +15,7 @@ jobs:
           - 6.0/fpm-alpine/Dockerfile
           - 6.0/fpm/Dockerfile
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v1.5.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
@@ -29,11 +29,20 @@ jobs:
     permissions:
       packages: write
       contents: read
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: 'Check out the repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: 'Set up QEMU'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
       - name: 'Log in to DockerHub'
@@ -61,6 +70,7 @@ jobs:
           push: true
           tags: ${{ steps.metadata-apache.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
+          platforms: ${{ matrix.platform }}
 
       - name: 'FPM variant metadata'
         id: metadata-fpm
@@ -81,6 +91,7 @@ jobs:
           push: true
           tags: ${{ steps.metadata-fpm.outputs.tags }}
           labels: ${{ steps.metadata-fpm.outputs.labels }}
+          platforms: ${{ matrix.platform }}
 
       - name: 'FPM Alpine variant metadata'
         id: metadata-fpm-alpine
@@ -101,3 +112,4 @@ jobs:
           push: true
           tags: ${{ steps.metadata-fpm-alpine.outputs.tags }}
           labels: ${{ steps.metadata-fpm-alpine.outputs.labels }}
+          platforms: ${{ matrix.platform }}

--- a/.github/workflows/build-latest-container-images.yaml
+++ b/.github/workflows/build-latest-container-images.yaml
@@ -2,7 +2,7 @@ name: Publish Latest Container Images
 on:
   push:
     tags:
-      - '5.*'
+      - '6.*'
 
 jobs:
   lint_dockerfiles:
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         dockerfile:
-          - 5.0/apache/Dockerfile
-          - 5.0/fpm-alpine/Dockerfile
-          - 5.0/fpm/Dockerfile
+          - 6.0/apache/Dockerfile
+          - 6.0/fpm-alpine/Dockerfile
+          - 6.0/fpm/Dockerfile
     steps:
       - uses: actions/checkout@v2
       - uses: hadolint/hadolint-action@v1.5.0
@@ -57,7 +57,7 @@ jobs:
       - name: 'Build and push latest Apache container images'
         uses: docker/build-push-action@v2
         with:
-          context: 5.0/apache
+          context: 6.0/apache
           push: true
           tags: ${{ steps.metadata-apache.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
@@ -77,7 +77,7 @@ jobs:
       - name: 'Build and push latest fpm container images'
         uses: docker/build-push-action@v2
         with:
-          context: 5.0/fpm
+          context: 6.0/fpm
           push: true
           tags: ${{ steps.metadata-fpm.outputs.tags }}
           labels: ${{ steps.metadata-fpm.outputs.labels }}
@@ -97,7 +97,7 @@ jobs:
       - name: 'Build and push latest fpm-alpine container images'
         uses: docker/build-push-action@v2
         with:
-          context: 5.0/fpm-alpine
+          context: 6.0/fpm-alpine
           push: true
           tags: ${{ steps.metadata-fpm-alpine.outputs.tags }}
           labels: ${{ steps.metadata-fpm-alpine.outputs.labels }}

--- a/.github/workflows/build-lts-container-images.yaml
+++ b/.github/workflows/build-lts-container-images.yaml
@@ -15,7 +15,7 @@ jobs:
           - 5.0/fpm-alpine/Dockerfile
           - 5.0/fpm/Dockerfile
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v1.5.0
         with:
           dockerfile: ${{ matrix.dockerfile }}
@@ -29,11 +29,20 @@ jobs:
     permissions:
       packages: write
       contents: read
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: 'Check out the repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: 'Set up QEMU'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
       - name: 'Log in to DockerHub'
@@ -61,6 +70,7 @@ jobs:
           push: true
           tags: ${{ steps.metadata-apache.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
+          platforms: ${{ matrix.platform }}
 
       - name: 'FPM variant metadata'
         id: metadata-fpm
@@ -81,6 +91,7 @@ jobs:
           push: true
           tags: ${{ steps.metadata-fpm.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
+          platforms: ${{ matrix.platform }}
 
       - name: 'FPM Alpine variant metadata'
         id: metadata-fpm-alpine
@@ -101,3 +112,4 @@ jobs:
           push: true
           tags: ${{ steps.metadata-fpm-alpine.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
+          platforms: ${{ matrix.platform }}

--- a/.github/workflows/build-lts-container-images.yaml
+++ b/.github/workflows/build-lts-container-images.yaml
@@ -64,7 +64,7 @@ jobs:
             latest=false
             suffix=-apache
       - name: 'Build and push LTS apache container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 5.0/apache
           push: true
@@ -85,7 +85,7 @@ jobs:
             latest=false
             suffix=-fpm
       - name: 'Build and push LTS fpm container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 5.0/fpm
           push: true
@@ -106,7 +106,7 @@ jobs:
             latest=false
             suffix=-fpm-alpine
       - name: 'Build and push LTS fpm-alpine container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 5.0/fpm-alpine
           push: true

--- a/.github/workflows/build-lts-container-images.yaml
+++ b/.github/workflows/build-lts-container-images.yaml
@@ -2,7 +2,7 @@ name: Publish LTS Container Images
 on:
   push:
     tags:
-      - '3.*'
+      - '5.*'
 
 jobs:
   lint_dockerfiles:
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         dockerfile:
-          - 3.0/apache/Dockerfile
-          - 3.0/fpm-alpine/Dockerfile
-          - 3.0/fpm/Dockerfile
+          - 5.0/apache/Dockerfile
+          - 5.0/fpm-alpine/Dockerfile
+          - 5.0/fpm/Dockerfile
     steps:
       - uses: actions/checkout@v2
       - uses: hadolint/hadolint-action@v1.5.0
@@ -57,7 +57,7 @@ jobs:
       - name: 'Build and push LTS apache container images'
         uses: docker/build-push-action@v2
         with:
-          context: 3.0/apache
+          context: 5.0/apache
           push: true
           tags: ${{ steps.metadata-apache.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
@@ -77,7 +77,7 @@ jobs:
       - name: 'Build and push LTS fpm container images'
         uses: docker/build-push-action@v2
         with:
-          context: 3.0/fpm
+          context: 5.0/fpm
           push: true
           tags: ${{ steps.metadata-fpm.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}
@@ -97,7 +97,7 @@ jobs:
       - name: 'Build and push LTS fpm-alpine container images'
         uses: docker/build-push-action@v2
         with:
-          context: 3.0/fpm-alpine
+          context: 5.0/fpm-alpine
           push: true
           tags: ${{ steps.metadata-fpm-alpine.outputs.tags }}
           labels: ${{ steps.metadata-apache.outputs.labels }}

--- a/.github/workflows/lint-dockerfiles.yaml
+++ b/.github/workflows/lint-dockerfiles.yaml
@@ -17,7 +17,7 @@ jobs:
           - 6.0/fpm/Dockerfile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hadolint/hadolint-action@v1.5.0
         with:
           dockerfile: ${{ matrix.dockerfile }}

--- a/.github/workflows/lint-dockerfiles.yaml
+++ b/.github/workflows/lint-dockerfiles.yaml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         dockerfile:
-          - 3.0/apache/Dockerfile
-          - 3.0/fpm-alpine/Dockerfile
-          - 3.0/fpm/Dockerfile
           - 5.0/apache/Dockerfile
           - 5.0/fpm-alpine/Dockerfile
           - 5.0/fpm/Dockerfile
+          - 6.0/apache/Dockerfile
+          - 6.0/fpm-alpine/Dockerfile
+          - 6.0/fpm/Dockerfile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-arm-container-images.yaml
+++ b/.github/workflows/test-arm-container-images.yaml
@@ -1,6 +1,12 @@
-name: Test Latest Container Images
+name: Test ARM Container Images
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'arm/**'
+  pull_request:
+    branches:
+      - 'arm/**'
 
 jobs:
   test_images:
@@ -12,6 +18,8 @@ jobs:
           - apache
           - fpm-alpine
           - fpm
+        platform:
+          - linux/arm64
     steps:
       - name: 'Check out the repo'
         uses: actions/checkout@v3
@@ -31,6 +39,7 @@ jobs:
           push: false
           load: true
           tags: docker.io/martialblog/limesurvey:6-${{ matrix.context }}
+          platforms: ${{ matrix.platform }}
 
       - name: 'Run Structure tests'
         uses: plexsystems/container-structure-test-action@v0.2.0

--- a/.github/workflows/test-latest-container-images.yaml
+++ b/.github/workflows/test-latest-container-images.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test_images:
-    name: Test Latest Container Images with Trivy
+    name: Test Latest Container Images
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: 'Build Container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 6.0/${{ matrix.context }}
           push: false

--- a/.github/workflows/test-latest-container-images.yaml
+++ b/.github/workflows/test-latest-container-images.yaml
@@ -22,13 +22,13 @@ jobs:
       - name: 'Build Container images'
         uses: docker/build-push-action@v2
         with:
-          context: 5.0/${{ matrix.context }}
+          context: 6.0/${{ matrix.context }}
           push: false
           load: true
-          tags: docker.io/martialblog/limesurvey:5-${{ matrix.context }}
+          tags: docker.io/martialblog/limesurvey:6-${{ matrix.context }}
 
       - name: 'Run Structure tests'
         uses: plexsystems/container-structure-test-action@v0.2.0
         with:
-          image: docker.io/martialblog/limesurvey:5-${{ matrix.context }}
+          image: docker.io/martialblog/limesurvey:6-${{ matrix.context }}
           config: tests/${{ matrix.context }}-tests.yaml

--- a/.github/workflows/test-latest-container-images.yaml
+++ b/.github/workflows/test-latest-container-images.yaml
@@ -12,12 +12,20 @@ jobs:
           - apache
           - fpm-alpine
           - fpm
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
       - name: 'Check out the repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: 'Set up QEMU'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'arm64,arm'
 
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: 'Build Container images'
         uses: docker/build-push-action@v2
@@ -26,6 +34,7 @@ jobs:
           push: false
           load: true
           tags: docker.io/martialblog/limesurvey:6-${{ matrix.context }}
+          platforms: ${{ matrix.platform }}
 
       - name: 'Run Structure tests'
         uses: plexsystems/container-structure-test-action@v0.2.0

--- a/.github/workflows/test-lts-container-images.yaml
+++ b/.github/workflows/test-lts-container-images.yaml
@@ -14,10 +14,13 @@ jobs:
           - fpm
     steps:
       - name: 'Check out the repo'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: 'Set up QEMU'
+        uses: docker/setup-qemu-action@v2
 
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: 'Build Container images'
         uses: docker/build-push-action@v2

--- a/.github/workflows/test-lts-container-images.yaml
+++ b/.github/workflows/test-lts-container-images.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test_images:
-    name: Test LTS Container Images with Trivy
+    name: Test LTS Container Images
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: 'Build Container images'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: 5.0/${{ matrix.context }}
           push: false

--- a/.github/workflows/test-lts-container-images.yaml
+++ b/.github/workflows/test-lts-container-images.yaml
@@ -22,13 +22,13 @@ jobs:
       - name: 'Build Container images'
         uses: docker/build-push-action@v2
         with:
-          context: 3.0/${{ matrix.context }}
+          context: 5.0/${{ matrix.context }}
           push: false
           load: true
-          tags: docker.io/martialblog/limesurvey:3-${{ matrix.context }}
+          tags: docker.io/martialblog/limesurvey:5-${{ matrix.context }}
 
       - name: 'Run Structure tests'
         uses: plexsystems/container-structure-test-action@v0.2.0
         with:
-          image: docker.io/martialblog/limesurvey:3-${{ matrix.context }}
+          image: docker.io/martialblog/limesurvey:5-${{ matrix.context }}
           config: tests/${{ matrix.context }}-tests.yaml

--- a/6.0/apache/Dockerfile
+++ b/6.0/apache/Dockerfile
@@ -1,0 +1,86 @@
+FROM docker.io/php:8.1-apache
+LABEL maintainer="markus@martialblog.de"
+
+# Install OS dependencies
+RUN set -ex; \
+        apt-get update && \
+        DEBIAN_FRONTEND=noninteractive \
+        apt-get install --no-install-recommends -y \
+        \
+        libldap2-dev \
+        libfreetype6-dev \
+        libjpeg-dev \
+        libonig-dev \
+        zlib1g-dev \
+        libc-client-dev \
+        libkrb5-dev \
+        libpng-dev \
+        libpq-dev \
+        libzip-dev \
+        libtidy-dev \
+        libsodium-dev \
+        netcat \
+        curl \
+        \
+        && apt-get -y autoclean; apt-get -y autoremove; \
+        rm -rf /var/lib/apt/lists/*
+
+# Link LDAP library for PHP ldap extension
+RUN set -ex; \
+        ln -fs /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/
+
+# Install PHP Plugins and Configure PHP imap plugin
+RUN set -ex; \
+        docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr && \
+        docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
+        docker-php-ext-install -j5 \
+        exif \
+        gd \
+        imap \
+        ldap \
+        mbstring \
+        pdo \
+        pdo_mysql \
+        pdo_pgsql \
+        pgsql \
+        sodium \
+        tidy \
+        zip
+
+# Apache configuration
+RUN a2enmod headers rewrite remoteip; \
+        {\
+        echo RemoteIPHeader X-Real-IP ;\
+        echo RemoteIPTrustedProxy 10.0.0.0/8 ;\
+        echo RemoteIPTrustedProxy 172.16.0.0/12 ;\
+        echo RemoteIPTrustedProxy 192.168.0.0/16 ;\
+        } > /etc/apache2/conf-available/remoteip.conf;\
+        a2enconf remoteip
+
+# Use the default production configuration
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+ARG version="6.0.0+230405"
+ARG sha256_checksum="ee636330911150b5f109323b6226c48d9fd7634856b251bbf66a75a29d4b4756"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=www-data
+ARG LISTEN_PORT=8080
+ENV LIMESURVEY_VERSION=$version
+
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository)
+RUN set -ex; \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
+        echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
+        \
+        tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \
+        rm -f "/tmp/limesurvey.tar.gz" && \
+        chown -R "$USER:$USER" /var/www/html /etc/apache2
+
+EXPOSE $LISTEN_PORT
+
+WORKDIR /var/www/html
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY vhosts-access-log.conf /etc/apache2/conf-enabled/other-vhosts-access-log.conf
+USER $USER
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/6.0/apache/entrypoint.sh
+++ b/6.0/apache/entrypoint.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# Entrypoint for Docker Container
+
+
+DB_TYPE=${DB_TYPE:-'mysql'}
+DB_HOST=${DB_HOST:-'mysql'}
+DB_PORT=${DB_PORT:-'3306'}
+DB_SOCK=${DB_SOCK:-}
+DB_NAME=${DB_NAME:-'limesurvey'}
+DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-'lime_'}
+DB_USERNAME=${DB_USERNAME:-'limesurvey'}
+DB_PASSWORD=${DB_PASSWORD:-}
+DB_MYSQL_ENGINE=${DB_MYSQL_ENGINE:-'MyISAM'}
+
+ENCRYPT_KEYPAIR=${ENCRYPT_KEYPAIR:-}
+ENCRYPT_PUBLIC_KEY=${ENCRYPT_PUBLIC_KEY:-}
+ENCRYPT_SECRET_KEY=${ENCRYPT_SECRET_KEY:-}
+ENCRYPT_NONCE=${ENCRYPT_NONCE:-}
+ENCRYPT_SECRET_BOX_KEY=${ENCRYPT_SECRET_BOX_KEY:-}
+
+ADMIN_USER=${ADMIN_USER:-'admin'}
+ADMIN_NAME=${ADMIN_NAME:-'admin'}
+ADMIN_EMAIL=${ADMIN_EMAIL:-'foobar@example.com'}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+
+BASE_URL=${BASE_URL:-}
+PUBLIC_URL=${PUBLIC_URL:-}
+URL_FORMAT=${URL_FORMAT:-'path'}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
+
+DEBUG=${DEBUG:-0}
+DEBUG_SQL=${DEBUG_SQL:-0}
+
+LISTEN_PORT=${LISTEN_PORT:-"8080"}
+
+if [ -z "$DB_PASSWORD" ]; then
+    echo >&2 'Error: Missing DB_PASSWORD'
+    exit 1
+fi
+
+if [ -z "$ADMIN_PASSWORD" ]; then
+    echo >&2 'Error: Missing ADMIN_PASSWORD'
+    exit 1
+fi
+
+if [ "$LISTEN_PORT" != "80" ]; then
+    echo "Info: Customizing Apache Listen port to $LISTEN_PORT"
+    sed -i "s/Listen 80\$/Listen $LISTEN_PORT/" /etc/apache2/ports.conf /etc/apache2/sites-available/000-default.conf
+fi
+
+# Check if database is available
+if [ -z "$DB_SOCK" ]; then
+    until nc -z -v -w30 "$DB_HOST" "$DB_PORT"
+    do
+        echo "Info: Waiting for database connection..."
+        sleep 5
+    done
+fi
+
+# Check if config already provisioned
+if [ -f application/config/config.php ]; then
+    echo 'Info: config.php already provisioned'
+else
+    echo 'Info: Generating config.php'
+
+    if [ "$DB_TYPE" = 'mysql' ]; then
+        echo 'Info: Using MySQL configuration'
+        DB_CHARSET=${DB_CHARSET:-'utf8mb4'}
+    fi
+
+    if [ "$DB_TYPE" = 'pgsql' ]; then
+        echo 'Info: Using PostgreSQL configuration'
+        DB_CHARSET=${DB_CHARSET:-'utf8'}
+    fi
+
+    if [ -n "$DB_SOCK" ]; then
+        echo 'Info: Using unix socket'
+        DB_CONNECT='unix_socket'
+    else
+        echo 'Info: Using TCP connection'
+        DB_CONNECT='host'
+    fi
+
+    if [ -z "$PUBLIC_URL" ]; then
+        echo 'Info: Setting PublicURL'
+    fi
+
+    cat <<EOF > application/config/config.php
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+return array(
+  'components' => array(
+    'db' => array(
+      'connectionString' => '$DB_TYPE:$DB_CONNECT=$DB_HOST;port=$DB_PORT;dbname=$DB_NAME;',
+      'emulatePrepare' => true,
+      'username' => '$DB_USERNAME',
+      'password' => '$DB_PASSWORD',
+      'charset' => '$DB_CHARSET',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
+    ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
+    'urlManager' => array(
+      'urlFormat' => '$URL_FORMAT',
+      'rules' => array(),
+      'showScriptName' => $SHOW_SCRIPT_NAME,
+    ),
+    'request' => array(
+      'baseUrl' => '$BASE_URL',
+     ),
+  ),
+  'config'=>array(
+    'publicurl'=>'$PUBLIC_URL',
+    'debug'=>$DEBUG,
+    'debugsql'=>$DEBUG_SQL,
+    'mysqlEngine' => '$DB_MYSQL_ENGINE',
+  )
+);
+
+EOF
+
+fi
+
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
+fi
+
+# Check if security config already provisioned
+if [ -f application/config/security.php ]; then
+    echo 'Info: security.php already provisioned'
+else
+    echo 'Info: Creating security.php'
+    if [ -n "$ENCRYPT_KEYPAIR" ]; then
+
+        cat <<EOF > application/config/security.php
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+\$config = array();
+\$config['encryptionkeypair'] = '$ENCRYPT_KEYPAIR';
+\$config['encryptionpublickey'] = '$ENCRYPT_PUBLIC_KEY';
+\$config['encryptionsecretkey'] = '$ENCRYPT_SECRET_KEY';
+\$config['encryptionnonce'] = '$ENCRYPT_NONCE';
+\$config['encryptionsecretboxkey'] = '$ENCRYPT_SECRET_BOX_KEY';
+return \$config;
+EOF
+    else
+        echo >&2 'Warning: No encryption keys were provided'
+        echo >&2 'Warning: A security.php config will be created by the application'
+        echo >&2 'Warning: THIS FILE NEEDS TO BE PERSISTENT'
+    fi
+fi
+
+# Check if LimeSurvey database is provisioned
+echo 'Info: Check if database already provisioned. Nevermind the Stack trace.'
+php application/commands/console.php updatedb
+
+PHP_UPDATEDB_EXIT_CODE=$?
+
+if [ $PHP_UPDATEDB_EXIT_CODE -eq 0 ]; then
+    echo 'Info: Database already provisioned'
+else
+    echo ''
+    echo 'Running console.php install'
+    php application/commands/console.php install "$ADMIN_USER" "$ADMIN_PASSWORD" "$ADMIN_NAME" "$ADMIN_EMAIL"
+fi
+
+exec "$@"

--- a/6.0/apache/vhosts-access-log.conf
+++ b/6.0/apache/vhosts-access-log.conf
@@ -1,0 +1,3 @@
+SetEnvIF User-Agent "(?i)(check|health|probe)" dontlog
+ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog ${APACHE_LOG_DIR}/access.log combined env=!dontlog

--- a/6.0/fpm-alpine/Dockerfile
+++ b/6.0/fpm-alpine/Dockerfile
@@ -1,0 +1,63 @@
+FROM docker.io/php:8.1-fpm-alpine
+LABEL maintainer="markus@martialblog.de"
+
+# Install OS dependencies
+RUN set -ex; \
+        apk add --no-cache --virtual .build-deps \
+        freetype-dev \
+        libpng-dev \
+        libzip-dev \
+        libjpeg-turbo-dev \
+        tidyhtml-dev \
+        libsodium-dev \
+        openldap-dev \
+        oniguruma-dev \
+        imap-dev \
+        postgresql-dev && \
+        apk add --no-cache netcat-openbsd bash
+
+# Install PHP Plugins
+RUN set -ex; \
+        docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr && \
+        docker-php-ext-configure imap --with-imap-ssl && \
+        docker-php-ext-install \
+        exif \
+        gd \
+        imap \
+        ldap \
+        mbstring \
+        pdo \
+        pdo_mysql \
+        pdo_pgsql \
+        pgsql \
+        sodium \
+        tidy \
+        zip
+
+ARG version="6.0.0+230405"
+ARG sha256_checksum="ee636330911150b5f109323b6226c48d9fd7634856b251bbf66a75a29d4b4756"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=www-data
+ENV LIMESURVEY_VERSION=$version
+
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository)
+RUN set -ex; \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
+        echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
+        \
+        tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \
+        \
+        rm -rf "/tmp/limesurvey.tar.gz" \
+        /var/www/html/docs \
+        /var/www/html/tests \
+        /var/www/html/*.md && \
+        chown -R "${USER}:root" /var/www/ ; \
+        chmod -R g=u /var/www
+
+EXPOSE 9000
+
+WORKDIR /var/www/html
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+USER $USER
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/6.0/fpm-alpine/entrypoint.sh
+++ b/6.0/fpm-alpine/entrypoint.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Entrypoint for Docker Container
+
+
+DB_TYPE=${DB_TYPE:-'mysql'}
+DB_HOST=${DB_HOST:-'mysql'}
+DB_PORT=${DB_PORT:-'3306'}
+DB_SOCK=${DB_SOCK:-}
+DB_NAME=${DB_NAME:-'limesurvey'}
+DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-'lime_'}
+DB_USERNAME=${DB_USERNAME:-'limesurvey'}
+DB_PASSWORD=${DB_PASSWORD:-}
+DB_MYSQL_ENGINE=${DB_MYSQL_ENGINE:-'MyISAM'}
+
+ENCRYPT_KEYPAIR=${ENCRYPT_KEYPAIR:-}
+ENCRYPT_PUBLIC_KEY=${ENCRYPT_PUBLIC_KEY:-}
+ENCRYPT_SECRET_KEY=${ENCRYPT_SECRET_KEY:-}
+ENCRYPT_NONCE=${ENCRYPT_NONCE:-}
+ENCRYPT_SECRET_BOX_KEY=${ENCRYPT_SECRET_BOX_KEY:-}
+
+ADMIN_USER=${ADMIN_USER:-'admin'}
+ADMIN_NAME=${ADMIN_NAME:-'admin'}
+ADMIN_EMAIL=${ADMIN_EMAIL:-'foobar@example.com'}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+
+BASE_URL=${BASE_URL:-}
+PUBLIC_URL=${PUBLIC_URL:-}
+URL_FORMAT=${URL_FORMAT:-'path'}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
+
+DEBUG=${DEBUG:-0}
+DEBUG_SQL=${DEBUG_SQL:-0}
+
+if [ -z "$DB_PASSWORD" ]; then
+    echo >&2 'Error: Missing DB_PASSWORD'
+    exit 1
+fi
+
+if [ -z "$ADMIN_PASSWORD" ]; then
+    echo >&2 'Error: Missing ADMIN_PASSWORD'
+    exit 1
+fi
+
+# Check if database is available
+if [ -z "$DB_SOCK" ]; then
+    until nc -z -v -w30 "$DB_HOST" "$DB_PORT"
+    do
+        echo "Info: Waiting for database connection..."
+        sleep 5
+    done
+fi
+
+# Check if config already provisioned
+if [ -f application/config/config.php ]; then
+    echo 'Info: config.php already provisioned'
+else
+    echo 'Info: Generating config.php'
+
+    if [ "$DB_TYPE" = 'mysql' ]; then
+        echo 'Info: Using MySQL configuration'
+        DB_CHARSET=${DB_CHARSET:-'utf8mb4'}
+    fi
+
+    if [ "$DB_TYPE" = 'pgsql' ]; then
+        echo 'Info: Using PostgreSQL configuration'
+        DB_CHARSET=${DB_CHARSET:-'utf8'}
+    fi
+
+    if [ -n "$DB_SOCK" ]; then
+        echo 'Info: Using unix socket'
+        DB_CONNECT='unix_socket'
+    else
+        echo 'Info: Using TCP connection'
+        DB_CONNECT='host'
+    fi
+
+    if [ -z "$PUBLIC_URL" ]; then
+        echo 'Info: Setting PublicURL'
+    fi
+
+    cat <<EOF > application/config/config.php
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+return array(
+  'components' => array(
+    'db' => array(
+      'connectionString' => '$DB_TYPE:$DB_CONNECT=$DB_HOST;port=$DB_PORT;dbname=$DB_NAME;',
+      'emulatePrepare' => true,
+      'username' => '$DB_USERNAME',
+      'password' => '$DB_PASSWORD',
+      'charset' => '$DB_CHARSET',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
+    ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
+    'urlManager' => array(
+      'urlFormat' => '$URL_FORMAT',
+      'rules' => array(),
+      'showScriptName' => $SHOW_SCRIPT_NAME,
+    ),
+    'request' => array(
+      'baseUrl' => '$BASE_URL',
+     ),
+  ),
+  'config'=>array(
+    'publicurl'=>'$PUBLIC_URL',
+    'debug'=>$DEBUG,
+    'debugsql'=>$DEBUG_SQL,
+    'mysqlEngine' => '$DB_MYSQL_ENGINE',
+  )
+);
+
+EOF
+
+fi
+
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
+fi
+
+# Check if security config already provisioned
+if [ -f application/config/security.php ]; then
+    echo 'Info: security.php already provisioned'
+else
+    echo 'Info: Creating security.php'
+    if [ -n "$ENCRYPT_KEYPAIR" ]; then
+
+        cat <<EOF > application/config/security.php
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+\$config = array();
+\$config['encryptionkeypair'] = '$ENCRYPT_KEYPAIR';
+\$config['encryptionpublickey'] = '$ENCRYPT_PUBLIC_KEY';
+\$config['encryptionsecretkey'] = '$ENCRYPT_SECRET_KEY';
+\$config['encryptionnonce'] = '$ENCRYPT_NONCE';
+\$config['encryptionsecretboxkey'] = '$ENCRYPT_SECRET_BOX_KEY';
+return \$config;
+EOF
+    else
+        echo >&2 'Warning: No encryption keys were provided'
+        echo >&2 'Warning: A security.php config will be created by the application'
+        echo >&2 'Warning: THIS FILE NEEDS TO BE PERSISTENT'
+    fi
+fi
+
+# Check if LimeSurvey database is provisioned
+echo 'Info: Check if database already provisioned. Nevermind the Stack trace.'
+php application/commands/console.php updatedb
+
+PHP_UPDATEDB_EXIT_CODE=$?
+
+if [ $PHP_UPDATEDB_EXIT_CODE -eq 0 ]; then
+    echo 'Info: Database already provisioned'
+else
+    echo ''
+    echo 'Running console.php install'
+    php application/commands/console.php install "$ADMIN_USER" "$ADMIN_PASSWORD" "$ADMIN_NAME" "$ADMIN_EMAIL"
+fi
+
+exec "$@"

--- a/6.0/fpm/Dockerfile
+++ b/6.0/fpm/Dockerfile
@@ -1,0 +1,70 @@
+FROM docker.io/php:8.1-fpm
+LABEL maintainer="markus@martialblog.de"
+
+# Install OS dependencies
+RUN set -ex; \
+        apt-get update && \
+        DEBIAN_FRONTEND=noninteractive \
+        apt-get install --no-install-recommends -y \
+        \
+        libldap2-dev \
+        libfreetype6-dev \
+        libjpeg-dev \
+        libonig-dev \
+        zlib1g-dev \
+        libc-client-dev \
+        libkrb5-dev \
+        libpng-dev \
+        libpq-dev \
+        libzip-dev \
+        libtidy-dev \
+        libsodium-dev \
+        netcat \
+        \
+        && apt-get -y autoclean; apt-get -y autoremove; \
+        rm -rf /var/lib/apt/lists/*
+
+# Link LDAP library for PHP ldap extension
+RUN set -ex; \
+        ln -fs /usr/lib/x86_64-linux-gnu/libldap.so /usr/lib/
+
+# Install PHP Plugins and Configure PHP imap plugin
+RUN set -ex; \
+        docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr && \
+        docker-php-ext-configure imap --with-kerberos --with-imap-ssl && \
+        docker-php-ext-install -j5 \
+        exif \
+        gd \
+        imap \
+        ldap \
+        mbstring \
+        pdo \
+        pdo_mysql \
+        pdo_pgsql \
+        pgsql \
+        sodium \
+        tidy \
+        zip
+
+ARG version="6.0.0+230405"
+ARG sha256_checksum="ee636330911150b5f109323b6226c48d9fd7634856b251bbf66a75a29d4b4756"
+ARG archive_url="https://github.com/LimeSurvey/LimeSurvey/archive/${version}.tar.gz"
+ARG USER=www-data
+ENV LIMESURVEY_VERSION=$version
+
+# Download, unzip and chmod LimeSurvey from GitHub (defaults to the official LimeSurvey/LimeSurvey repository)
+RUN set -ex; \
+        curl -sSL "${archive_url}" --output /tmp/limesurvey.tar.gz && \
+        echo "${sha256_checksum}  /tmp/limesurvey.tar.gz" | sha256sum -c - && \
+        \
+        tar xzvf "/tmp/limesurvey.tar.gz" --strip-components=1 -C /var/www/html/ && \
+        rm -f "/tmp/limesurvey.tar.gz" && \
+        chown -R "$USER:$USER" /var/www/html
+
+EXPOSE 9000
+
+WORKDIR /var/www/html
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+USER $USER
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/6.0/fpm/entrypoint.sh
+++ b/6.0/fpm/entrypoint.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Entrypoint for Docker Container
+
+
+DB_TYPE=${DB_TYPE:-'mysql'}
+DB_HOST=${DB_HOST:-'mysql'}
+DB_PORT=${DB_PORT:-'3306'}
+DB_SOCK=${DB_SOCK:-}
+DB_NAME=${DB_NAME:-'limesurvey'}
+DB_TABLE_PREFIX=${DB_TABLE_PREFIX:-'lime_'}
+DB_USERNAME=${DB_USERNAME:-'limesurvey'}
+DB_PASSWORD=${DB_PASSWORD:-}
+DB_MYSQL_ENGINE=${DB_MYSQL_ENGINE:-'MyISAM'}
+
+ENCRYPT_KEYPAIR=${ENCRYPT_KEYPAIR:-}
+ENCRYPT_PUBLIC_KEY=${ENCRYPT_PUBLIC_KEY:-}
+ENCRYPT_SECRET_KEY=${ENCRYPT_SECRET_KEY:-}
+ENCRYPT_NONCE=${ENCRYPT_NONCE:-}
+ENCRYPT_SECRET_BOX_KEY=${ENCRYPT_SECRET_BOX_KEY:-}
+
+ADMIN_USER=${ADMIN_USER:-'admin'}
+ADMIN_NAME=${ADMIN_NAME:-'admin'}
+ADMIN_EMAIL=${ADMIN_EMAIL:-'foobar@example.com'}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
+
+BASE_URL=${BASE_URL:-}
+PUBLIC_URL=${PUBLIC_URL:-}
+URL_FORMAT=${URL_FORMAT:-'path'}
+SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
+TABLE_SESSION=${TABLE_SESSION:-}
+
+DEBUG=${DEBUG:-0}
+DEBUG_SQL=${DEBUG_SQL:-0}
+
+if [ -z "$DB_PASSWORD" ]; then
+    echo >&2 'Error: Missing DB_PASSWORD'
+    exit 1
+fi
+
+if [ -z "$ADMIN_PASSWORD" ]; then
+    echo >&2 'Error: Missing ADMIN_PASSWORD'
+    exit 1
+fi
+
+# Check if database is available
+if [ -z "$DB_SOCK" ]; then
+    until nc -z -v -w30 "$DB_HOST" "$DB_PORT"
+    do
+        echo "Info: Waiting for database connection..."
+        sleep 5
+    done
+fi
+
+# Check if config already provisioned
+if [ -f application/config/config.php ]; then
+    echo 'Info: config.php already provisioned'
+else
+    echo 'Info: Generating config.php'
+
+    if [ "$DB_TYPE" = 'mysql' ]; then
+        echo 'Info: Using MySQL configuration'
+        DB_CHARSET=${DB_CHARSET:-'utf8mb4'}
+    fi
+
+    if [ "$DB_TYPE" = 'pgsql' ]; then
+        echo 'Info: Using PostgreSQL configuration'
+        DB_CHARSET=${DB_CHARSET:-'utf8'}
+    fi
+
+    if [ -n "$DB_SOCK" ]; then
+        echo 'Info: Using unix socket'
+        DB_CONNECT='unix_socket'
+    else
+        echo 'Info: Using TCP connection'
+        DB_CONNECT='host'
+    fi
+
+    if [ -z "$PUBLIC_URL" ]; then
+        echo 'Info: Setting PublicURL'
+    fi
+
+    cat <<EOF > application/config/config.php
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+return array(
+  'components' => array(
+    'db' => array(
+      'connectionString' => '$DB_TYPE:$DB_CONNECT=$DB_HOST;port=$DB_PORT;dbname=$DB_NAME;',
+      'emulatePrepare' => true,
+      'username' => '$DB_USERNAME',
+      'password' => '$DB_PASSWORD',
+      'charset' => '$DB_CHARSET',
+      'tablePrefix' => '${DB_TABLE_PREFIX//[[:space:]]/}',
+    ),
+    //'session' => array (
+    //   'class' => 'application.core.web.DbHttpSession',
+    //   'connectionID' => 'db',
+    //   'sessionTableName' => '{{sessions}}',
+    //),
+    'urlManager' => array(
+      'urlFormat' => '$URL_FORMAT',
+      'rules' => array(),
+      'showScriptName' => $SHOW_SCRIPT_NAME,
+    ),
+    'request' => array(
+      'baseUrl' => '$BASE_URL',
+     ),
+  ),
+  'config'=>array(
+    'publicurl'=>'$PUBLIC_URL',
+    'debug'=>$DEBUG,
+    'debugsql'=>$DEBUG_SQL,
+    'mysqlEngine' => '$DB_MYSQL_ENGINE',
+  )
+);
+
+EOF
+
+fi
+
+# Enable Table Sessions if required
+if [ -n "$TABLE_SESSION" ]; then
+    echo 'Info: Setting Table Session'
+    # Remove the comments in the config
+    sed -i "s/\/\///g" application/config/config.php
+fi
+
+# Check if security config already provisioned
+if [ -f application/config/security.php ]; then
+    echo 'Info: security.php already provisioned'
+else
+    echo 'Info: Creating security.php'
+    if [ -n "$ENCRYPT_KEYPAIR" ]; then
+
+        cat <<EOF > application/config/security.php
+<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
+\$config = array();
+\$config['encryptionkeypair'] = '$ENCRYPT_KEYPAIR';
+\$config['encryptionpublickey'] = '$ENCRYPT_PUBLIC_KEY';
+\$config['encryptionsecretkey'] = '$ENCRYPT_SECRET_KEY';
+\$config['encryptionnonce'] = '$ENCRYPT_NONCE';
+\$config['encryptionsecretboxkey'] = '$ENCRYPT_SECRET_BOX_KEY';
+return \$config;
+EOF
+    else
+        echo >&2 'Warning: No encryption keys were provided'
+        echo >&2 'Warning: A security.php config will be created by the application'
+        echo >&2 'Warning: THIS FILE NEEDS TO BE PERSISTENT'
+    fi
+fi
+
+# Check if LimeSurvey database is provisioned
+echo 'Info: Check if database already provisioned. Nevermind the Stack trace.'
+php application/commands/console.php updatedb
+
+PHP_UPDATEDB_EXIT_CODE=$?
+
+if [ $PHP_UPDATEDB_EXIT_CODE -eq 0 ]; then
+    echo 'Info: Database already provisioned'
+else
+    echo ''
+    echo 'Running console.php install'
+    php application/commands/console.php install "$ADMIN_USER" "$ADMIN_PASSWORD" "$ADMIN_NAME" "$ADMIN_EMAIL"
+fi
+
+exec "$@"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,9 @@ make fpm-alpine-latest
 
 container-structure-test test --image  docker.io/martialblog/limesurvey:5-fpm --config tests/fpm-tests.yaml
 ```
+
+### ARM Platform
+
+Changes related to the ARM platform should use branches starting with the `arm/` prefix, this ensures the GitHub Actions are triggered.
+
+Background: ARM builds take a long time to finish on the GitHub Runners.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 RUNTIME?=podman
 
 apache-lts:
-	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:3-apache 3.0/apache
-apache-latest:
 	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:5-apache 5.0/apache
+apache-latest:
+	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:6-apache 6.0/apache
 fpm-alpine-lts:
-	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:3-fpm-alpine 3.0/fpm-alpine
-fpm-alpine-latest:
 	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:5-fpm-alpine 5.0/fpm-alpine
+fpm-alpine-latest:
+	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:6-fpm-alpine 6.0/fpm-alpine
 fpm-lts:
-	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:3-fpm 3.0/fpm
-fpm-latest:
 	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:5-fpm 5.0/fpm
+fpm-latest:
+	$(RUNTIME) build --pull -t docker.io/martialblog/limesurvey:6-fpm 6.0/fpm

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Dockerfile to build a [LimeSurvey](https://limesurvey.org) Image for the Docker 
 
 ## Supported tags and respective Dockerfile links
 
+- [`6-apache`, `6.<BUILD-NUMBER>-apache`, `latest` ](https://github.com/martialblog/docker-limesurvey/blob/master/6.0/apache/Dockerfile)
+- [`6-fpm`, `6.<BUILD-NUMBER>-fpm`](https://github.com/martialblog/docker-limesurvey/blob/master/6.0/fpm/Dockerfile)
+- [`6-fpm-alpine`, `6.<BUILD-NUMBER>-fpm-alpine`](https://github.com/martialblog/docker-limesurvey/blob/master/6.0/fpm-alpine/Dockerfile)
 - [`5-apache`, `5.<BUILD-NUMBER>-apache`, `latest` ](https://github.com/martialblog/docker-limesurvey/blob/master/5.0/apache/Dockerfile)
 - [`5-fpm`, `5.<BUILD-NUMBER>-fpm`](https://github.com/martialblog/docker-limesurvey/blob/master/5.0/fpm/Dockerfile)
 - [`5-fpm-alpine`, `5.<BUILD-NUMBER>-fpm-alpine`](https://github.com/martialblog/docker-limesurvey/blob/master/5.0/fpm-alpine/Dockerfile)
-- [`3-apache`, `3.<BUILD-NUMBER>-apache`](https://github.com/martialblog/docker-limesurvey/blob/master/3.0/apache/Dockerfile)
-- [`3-fpm`, `3.<BUILD-NUMBER>-fpm`](https://github.com/martialblog/docker-limesurvey/blob/master/3.0/fpm/Dockerfile)
-- [`3-fpm-alpine`, `3.<BUILD-NUMBER>-fpm-alpine`](https://github.com/martialblog/docker-limesurvey/blob/master/3.0/fpm-alpine/Dockerfile)
 
 # Using the Apache Image
 
@@ -129,8 +129,8 @@ If you are running LimeSurvey behind a Reverse Proxy you might need some additio
 | ENCRYPT_KEYPAIR  | Data encryption keypair                  |
 | ENCRYPT_PUBLIC_KEY | Data encryption public key             |
 | ENCRYPT_SECRET_KEY | Data encryption secret key             |
-| ENCRYPT_NONCE      | Data encryption nonce (used in 5.0)    |
-| ENCRYPT_SECRET_BOX_KEY | Data encryption secret box key (used in 5.0)             |
+| ENCRYPT_NONCE      | Data encryption nonce (used in 5.0 and higher) |
+| ENCRYPT_SECRET_BOX_KEY | Data encryption secret box key (used in 5.0 and higher) |
 | LISTEN_PORT     | Apache: Listen port. Default: 8080        |
 
 For further details on the settings see: https://manual.limesurvey.org/Optional_settings#Advanced_Path_Settings
@@ -171,6 +171,12 @@ local     docker-limesurvey_lime
 $ docker volume rm docker-limesurvey_lime
 ```
 
+## Upgrading to 6.0 from 5.x
+
+The LimeSurvey 6 Images will use PHP 8.1 as Base Images.
+
+LimeSurvey 5 will become the new LTS. LimeSurvey 3 is deprecated and will no longer be supported.
+
 ## Upgrading to 5.0 from 4.x
 
 The default user in the Container will now be *www-data* (uid 33 in Debian, uid 82 in Alpine), any volumes mounted need the corresponding permissions:
@@ -195,10 +201,12 @@ If you are using the Apache2 Images, the default port will now be **8080**. Depe
 
 ## LimeSurvey behind a reverse proxy with a subdirectory
 
-When running LimeSurvey behind a reverse proxy with a subdirectory (i.e. example.com/limesurvey), the admin area might not be displayed correctly due to a routing issue. The application will forward you to the base url regardless. See:
-- https://github.com/martialblog/docker-limesurvey/issues/49
+When running LimeSurvey behind a reverse proxy with a subdirectory (i.e. example.com/limesurvey), the admin area might not be displayed correctly due to a routing issue. The application will forward you to the BASE URL regardless.
+
+This might be fixed by setting the HTTP Host Header in the reverse proxy explicitly.
+
+See:
 - https://github.com/martialblog/docker-limesurvey/issues/127
-- https://github.com/martialblog/docker-limesurvey/issues/106
 
 # References
 

--- a/docker-compose.apache.yml
+++ b/docker-compose.apache.yml
@@ -1,7 +1,7 @@
 version: "3.0"
 services:
   limesurvey:
-    image: docker.io/martialblog/limesurvey:3-apache
+    image: docker.io/martialblog/limesurvey:latest
     links:
       - lime-db
     depends_on:

--- a/docker-compose.fpm-certbot.yml
+++ b/docker-compose.fpm-certbot.yml
@@ -2,7 +2,7 @@ version: "3.0"
 services:
   limesurvey:
     build:
-      context: 5.0/fpm/
+      context: 6.0/fpm/
       dockerfile: Dockerfile
     volumes:
       # Hint: This is just an example, change /tmp to something persistent

--- a/docker-compose.fpm.alpine.yml
+++ b/docker-compose.fpm.alpine.yml
@@ -2,7 +2,7 @@ version: "3.0"
 services:
   limesurvey:
     build:
-      context: 5.0/fpm-alpine/
+      context: 6.0/fpm-alpine/
       dockerfile: Dockerfile
     volumes:
       # Hint: This is just an example, change /tmp to something persistent

--- a/docker-compose.fpm.yml
+++ b/docker-compose.fpm.yml
@@ -2,7 +2,7 @@ version: "3.0"
 services:
   limesurvey:
     build:
-      context: 5.0/fpm/
+      context: 6.0/fpm/
       dockerfile: Dockerfile
     volumes:
       # Hint: This is just an example, change /tmp to something persistent

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -3,7 +3,7 @@ services:
   limesurvey:
     build:
       # Hint: Change it to 3.0/apache/ if you want to use LimeSurvey 3.*
-      context: 5.0/apache/
+      context: 6.0/apache/
       dockerfile: Dockerfile
     volumes:
       # Hint: This is just an example, change /tmp to something persistent

--- a/docker-compose.traefik.domain.yml
+++ b/docker-compose.traefik.domain.yml
@@ -2,7 +2,7 @@ version: "3.0"
 services:
   limesurvey:
     build:
-      context: 5.0/apache/
+      context: 6.0/apache/
       dockerfile: Dockerfile
     labels:
       traefik.enable: 'true'

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -2,7 +2,7 @@ version: "3.0"
 services:
   limesurvey:
     build:
-      context: 5.0/apache/
+      context: 6.0/apache/
       dockerfile: Dockerfile
     labels:
       traefik.enable: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.0"
 services:
   limesurvey:
     build:
-      context: 5.0/apache/
+      context: 6.0/apache/
       dockerfile: Dockerfile
     volumes:
       # Hint: This is just an example, change /tmp to something persistent

--- a/tests/apache-tests.yaml
+++ b/tests/apache-tests.yaml
@@ -21,9 +21,6 @@ fileExistenceTests:
     path: '/var/www/html/admin/index.php'
     shouldExist: true
     permissions: '-rw-rw-r--'
-  - name: 'Ldap syslink'
-    path: '/usr/lib/x86_64-linux-gnu/libldap.so'
-    shouldExist: true
   - name:  "Dependencies - PHP - gd"
     path: '/usr/local/etc/php/conf.d/docker-php-ext-gd.ini'
     shouldExist: true

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -34,5 +34,5 @@ sed -r -i -e "s/[0-9]+(\.[0-9]+)+\+[0-9]+/$NEW_VERSION/" "$MAJOR_VERSION/apache/
 sed -r -i -e "s/[A-Fa-f0-9]{64}/$SHA256_CHECKSUM/" "$MAJOR_VERSION/apache/Dockerfile" "$MAJOR_VERSION/fpm/Dockerfile" "$MAJOR_VERSION/fpm-alpine/Dockerfile"
 
 # After that, check and commit
-echo "git add 3.0 ; git commit -m 'Upgrading to LTS Version ${NEW_VERSION}' && git tag ${NEW_TAG}"
-echo "git add 5.0 ; git commit -m 'Upgrading to Version ${NEW_VERSION}' && git tag ${NEW_TAG}"
+echo "git add 5.0 ; git commit -m 'Upgrading to LTS Version ${NEW_VERSION}' && git tag ${NEW_TAG}"
+echo "git add 6.0 ; git commit -m 'Upgrading to Version ${NEW_VERSION}' && git tag ${NEW_TAG}"


### PR DESCRIPTION
LimeSurvey announced the Release 6.0. With that 5.0 becomes the new LTS and 3.0 is deprecated (support ends Q2 2023).

Updated the repo accordingly.

PR includes:

- Update GitHub Action versions
- Add ARM build in GitHub Actions
- Update Repository for new 6.0 Release
