### PR TITLE
Drop build dependencies from Alpine variant

### DIFF
--- a/3.0/fpm-alpine/Dockerfile
+++ b/3.0/fpm-alpine/Dockerfile
@@ -2,6 +2,10 @@ FROM docker.io/php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies
+RUN apk add --no-cache netcat-openbsd bash
+
+# Install PHP Plugins
+# hadolint ignore=DL3019
 RUN set -ex; \
         apk add --no-cache --virtual .build-deps \
         freetype-dev \
@@ -13,14 +17,13 @@ RUN set -ex; \
         openldap-dev \
         oniguruma-dev \
         imap-dev \
-        postgresql-dev && \
-        apk add --no-cache netcat-openbsd bash
-
-# Install PHP Plugins
-RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr && \
-        docker-php-ext-configure imap --with-imap-ssl && \
-        docker-php-ext-install \
+        postgresql-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure imap --with-imap-ssl; \
+    docker-php-ext-install -j "$(nproc)" \
+        exif \
         gd \
         imap \
         ldap \
@@ -31,7 +34,17 @@ RUN set -ex; \
         pgsql \
         sodium \
         tidy \
-        zip
+        zip \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --no-network --virtual .limesurvey-phpext-rundeps $runDeps; \
+    apk del --no-network .build-deps
 
 ARG version="3.28.56+230404"
 ARG sha256_checksum="abfdc800d97feabbd448df4a2cfa72a954d2f6b013475132b0691ac2563e7228"

--- a/5.0/fpm-alpine/Dockerfile
+++ b/5.0/fpm-alpine/Dockerfile
@@ -2,6 +2,10 @@ FROM docker.io/php:8.0-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies
+RUN apk add --no-cache netcat-openbsd bash
+
+# Install PHP Plugins
+# hadolint ignore=DL3019
 RUN set -ex; \
         apk add --no-cache --virtual .build-deps \
         freetype-dev \
@@ -13,14 +17,12 @@ RUN set -ex; \
         openldap-dev \
         oniguruma-dev \
         imap-dev \
-        postgresql-dev && \
-        apk add --no-cache netcat-openbsd bash
-
-# Install PHP Plugins
-RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr && \
-        docker-php-ext-configure imap --with-imap-ssl && \
-        docker-php-ext-install \
+        postgresql-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure imap --with-imap-ssl; \
+    docker-php-ext-install -j "$(nproc)" \
         exif \
         gd \
         imap \
@@ -32,7 +34,17 @@ RUN set -ex; \
         pgsql \
         sodium \
         tidy \
-        zip
+        zip \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --no-network --virtual .limesurvey-phpext-rundeps $runDeps; \
+    apk del --no-network .build-deps
 
 ARG version="5.6.21+230518"
 ARG sha256_checksum="47ae13c225b7986e65913e3d2206fd53a7acf511166d2d1a73b5257830eacfef"

--- a/6.0/fpm-alpine/Dockerfile
+++ b/6.0/fpm-alpine/Dockerfile
@@ -2,6 +2,10 @@ FROM docker.io/php:8.1-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies
+RUN apk add --no-cache netcat-openbsd bash
+
+# Install PHP Plugins
+# hadolint ignore=DL3019
 RUN set -ex; \
         apk add --no-cache --virtual .build-deps \
         freetype-dev \
@@ -13,14 +17,12 @@ RUN set -ex; \
         openldap-dev \
         oniguruma-dev \
         imap-dev \
-        postgresql-dev && \
-        apk add --no-cache netcat-openbsd bash
-
-# Install PHP Plugins
-RUN set -ex; \
-        docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr && \
-        docker-php-ext-configure imap --with-imap-ssl && \
-        docker-php-ext-install \
+        postgresql-dev \
+    ; \
+    \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-configure imap --with-imap-ssl; \
+    docker-php-ext-install -j "$(nproc)" \
         exif \
         gd \
         imap \
@@ -32,7 +34,17 @@ RUN set -ex; \
         pgsql \
         sodium \
         tidy \
-        zip
+        zip \
+    ; \
+    \
+    runDeps="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )"; \
+    apk add --no-network --virtual .limesurvey-phpext-rundeps $runDeps; \
+    apk del --no-network .build-deps
 
 ARG version="6.0.7+230515"
 ARG sha256_checksum="de13467a4963d9759bd24300b5bd5b07f3149b0a62943180afaadfbd0513fef7"


### PR DESCRIPTION
This reduces the image size by ~50%.
There is a similar approach for the Debian base if you're interested.