### PR TITLE
doc/credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For further details on the settings see: https://manual.limesurvey.org/Optional_
 
 # Running LimeSurvey with docker-compose
 
-The easiest way to get a fully featured and functional setup is using a docker-compose file. Several examples are provided in the [repository](https://github.com/martialblog/docker-limesurvey).
+The easiest way to get a fully featured and functional setup is using a docker-compose file. Several examples are provided in the [repository](https://github.com/martialblog/docker-limesurvey). To sign into the example admin panel the credentials are username: *admin* password: *foobar*.
 
 ```
 docker-compose up
@@ -159,7 +159,6 @@ http://localhost:8080/
 
 # Backend
 http://localhost:8080/index.php/admin
-_(default account/password used in examples: admin/foobar)_
 ```
 
 # Running LimeSurvey with Helm

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ http://localhost:8080/
 
 # Backend
 http://localhost:8080/index.php/admin
+_(default account/password used in examples: admin/foobar)_
 ```
 
 # Running LimeSurvey with Helm

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ If you are running LimeSurvey behind a Reverse Proxy you might need some additio
 | DB_MYSQL_ENGINE | MySQL engine used for survey tables (values: MyISAM, InnoDB, default: MyISAM)       |
 | DB_USERNAME     | Database user                             |
 | DB_PASSWORD     | Database user's password                  |
-| ADMIN_USER      | Initial LimeSurvey Admin User             |
-| ADMIN_NAME      | Initial LimeSurvey Admin Username         |
+| ADMIN_USER      | Initial LimeSurvey Admin Username (for signing into admin panel)             |
+| ADMIN_NAME      | Initial LimeSurvey Admin Name             |
 | ADMIN_EMAIL     | Initial LimeSurvey Admin Email            |
-| ADMIN_PASSWORD  | Initial LimeSurvey Admin Password         |
+| ADMIN_PASSWORD  | Initial LimeSurvey Admin Password (for signing into admin panel)         |
 | PUBLIC_URL      | Public URL for public scripts             |
 | BASE_URL        | Application Base URL                      |
 | URL_FORMAT      | URL Format. path or get                   |
@@ -149,7 +149,7 @@ For further details on the settings see: https://manual.limesurvey.org/Optional_
 
 # Running LimeSurvey with docker-compose
 
-The easiest way to get a fully featured and functional setup is using a docker-compose file. Several examples are provided in the [repository](https://github.com/martialblog/docker-limesurvey). To sign into the example admin panel the credentials are username: *admin* password: *foobar*.
+The easiest way to get a fully featured and functional setup is using a docker-compose file. Several examples are provided in the [repository](https://github.com/martialblog/docker-limesurvey).
 
 ```
 docker-compose up
@@ -160,6 +160,8 @@ http://localhost:8080/
 # Backend
 http://localhost:8080/index.php/admin
 ```
+
+Please note / warning: To sign into the admin panel in the examples, the credentials are username: *admin* password: *foobar*, however, if you are planning for any use beyond testing, it is highly recommended that you use environment variables to define a secure username and password.
 
 # Running LimeSurvey with Helm
 


### PR DESCRIPTION
I thought it would be good to include the credentials used in the example docker-compose files so that people could quickly sign into the admin panel without have to poke around the code.