### PR TITLE
The volume path for db-data was wrong.   needed data sub-folder.   Without that wasn't persisting the db on stop of container.

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -25,7 +25,7 @@ services:
     image: docker.io/postgres:10-alpine
     restart: always
     volumes:
-      - db-data:/var/lib/postgresql
+      - db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_USER=limesurvey
       - POSTGRES_DB=limesurvey


### PR DESCRIPTION
In using this docker-compose found that because the db-data volume was different to that in the postgres:10-alpine dockerfile the system did not persist data between down and up of docker-compose.   Added /data to volume path and now all works.