### PR TITLE
Bump PHP to 8.1 in 6.x images

### DIFF
--- a/6.0/apache/Dockerfile
+++ b/6.0/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/php:8.0-apache
+FROM docker.io/php:8.1-apache
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies

--- a/6.0/fpm-alpine/Dockerfile
+++ b/6.0/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/php:8.0-fpm-alpine
+FROM docker.io/php:8.1-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies

--- a/6.0/fpm/Dockerfile
+++ b/6.0/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/php:8.0-fpm
+FROM docker.io/php:8.1-fpm
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies


### PR DESCRIPTION
PHP 8.2.0 was released 08 Dec 2022 (see https://www.php.net/releases/index.php).

This repo uses Renovate and that may already bump these automatically, so let me know if you're explicitly avoiding bumping the version.

EDIT: tests are failing, so maybe that's enough reason to punt the update 😅.
