### PR TITLE
Improve removal of dev packages

### DIFF
--- a/6.0/apache/Dockerfile
+++ b/6.0/apache/Dockerfile
@@ -64,6 +64,13 @@ RUN set -ex; \
                 | cut -d: -f1 \
                 | sort -u \
                 | xargs -rt apt-mark manual; \
+        ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+                | awk '$3 ~ /^\/lib/ { print "/usr"$3 }' \
+                | sort -u \
+                | xargs -r dpkg-query -S \
+                | cut -d: -f1 \
+                | sort -u \
+                | xargs -rt apt-mark manual; \
         \
         apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
         rm -rf /var/lib/apt/lists/*

--- a/6.0/fpm/Dockerfile
+++ b/6.0/fpm/Dockerfile
@@ -64,6 +64,13 @@ RUN set -ex; \
                 | cut -d: -f1 \
                 | sort -u \
                 | xargs -rt apt-mark manual; \
+        ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+                | awk '$3 ~ /^\/lib/ { print "/usr"$3 }' \
+                | sort -u \
+                | xargs -r dpkg-query -S \
+                | cut -d: -f1 \
+                | sort -u \
+                | xargs -rt apt-mark manual; \
         \
         apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
         rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
 - Due to the PHP libs being at /lib in newer Image versions the apt-mark manual wouldn't catch them and remove important libraries. This extends the marking of required packages.

Relates to #177 