### PR TITLE
Keep all upload data persistent and advice on redirections issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You may also consider separated volumes for each subdirectory.
 If your deployment is behind an additional proxy that listens on a different port than the Apache in the
 container, you may notice some issues with redirects generated from Apache, e.g. when redirecting
 URLs to the cannonical version. Apache will try to add the port it's listening on to the URL.
-To prevent this, you may edit the Apache configuration and add `ServerName` directive with your
+To prevent this, you may edit the Apache configuration and add the `ServerName` directive with your
 domain. In this case, Apache won't try to construct it automatically and use the configured value.
 
 # References

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ To keep them persistent, you need to ensure that all subdirectories of `upload` 
 The easiest way is to mount the whole `/var/www/html/upload`. If you want to update an existing deployment
 from previous configuration, please keep in mind that just changing the mount path may cause data loss 
 (e.g. already uploaded themes). Please backup your data from the container before any modifications.
-You may also consider separated volumes for every subdirectory.
+You may also consider separated volumes for each subdirectory.
 
 ## Apache generates redirects with internal port / URLs don't work without trailing slash
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You may also consider separated volumes for each subdirectory.
 
 ## Apache generates redirects with internal port / URLs don't work without trailing slash
 
-If your deployment is behind additional proxy that listen on a different port than the Apache in the
+If your deployment is behind an additional proxy that listens on a different port than the Apache in the
 container, you may notice some issues with redirects generated from Apache, e.g. when redirecting
 URLs to the cannonical version. Apache will try to add the port it's listening on to the URL.
 To prevent this, you may edit the Apache configuration and add `ServerName` directive with your

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ LimeSurvey requires an external database (MySQL, PostgreSQL) to run. See *docker
 
 To preserve the uploaded files assign the upload folder into a volume. See *docker-compose.yml* for example.
 
-Path: `/var/www/html/upload/surveys`
+Path: `/var/www/html/upload`
 
 **Hint**: The mounted directory must be owned by the webserver user (e.g. www-data)
 
@@ -221,6 +221,26 @@ This might be fixed by setting the HTTP Host Header in the reverse proxy explici
 
 See:
 - https://github.com/martialblog/docker-limesurvey/issues/127
+
+## Updating or rebuilding container removes themes/plugins/...
+
+The `/var/www/html/upload` directory contains multiple subdirectories for different kind of persistent data,
+e.g. themes, plugins and survey uploads. In past, the example configuration recommended only the persistent
+volume for survey uploads. In such a situation, any rebuild of the container will remove other stored data.
+To keep them persisten, you need to ensure that all subdirectories of `upload` are stored in a volume.
+
+The easiest way is to mount the whole `/var/www/html/upload`. If you want to update an existing deployment
+from previous configuration, please keep in mind that just changing the mount path may cause data loss 
+(e.g. already uploaded themes). Please backup your data from the container before any modifications.
+You may also consider separated volumes for every subdirectory.
+
+## Apache generates redirects with internal port / URLs don't work without trailing slash
+
+If your deployment is behind additional proxy that listen on a different port than the Apache in the
+container, you may notice some issues with redirects generated from Apache, e.g. when redirecting
+URLs to the cannonical version. Apache will try to add the port it's listening on to the URL.
+To prevent this, you may edit the Apache configuration and add `ServerName` directive with your
+domain. In this case, Apache won't try to construct it automatically and use the configured value.
 
 # References
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ See:
 The `/var/www/html/upload` directory contains multiple subdirectories for different kind of persistent data,
 e.g. themes, plugins and survey uploads. In past, the example configuration recommended only the persistent
 volume for survey uploads. In such a situation, any rebuild of the container will remove other stored data.
-To keep them persisten, you need to ensure that all subdirectories of `upload` are stored in a volume.
+To keep them persistent, you need to ensure that all subdirectories of `upload` are stored in a volume.
 
 The easiest way is to mount the whole `/var/www/html/upload`. If you want to update an existing deployment
 from previous configuration, please keep in mind that just changing the mount path may cause data loss 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -17,7 +17,7 @@ services:
       - PUBLIC_URL=foobar.com
     volumes:
       # All subdirectories of the upload may contain
-      # data intended to be persisten (e.g. themes)
+      # data intended to be persistent (e.g. themes)
       - limesurvey:/var/www/html/upload
     ports:
       - 8080:8080

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,7 +16,9 @@ services:
       - ADMIN_EMAIL=admin@example.com
       - PUBLIC_URL=foobar.com
     volumes:
-      - limesurvey:/var/www/html/upload/surveys
+      # All subdirectories of the upload may contain
+      # data intended to be persisten (e.g. themes)
+      - limesurvey:/var/www/html/upload
     ports:
       - 8080:8080
     depends_on:

--- a/examples/apache-example.conf
+++ b/examples/apache-example.conf
@@ -1,6 +1,8 @@
 <VirtualHost *:8080>
 	ServerAdmin foo@bar.com
 	DocumentRoot /var/www/html
+	# ServerName may help with issues with redirections - see #196
+	# ServerName your-domain.com
         Alias /limesurvey "/var/www/html"
 
         <Directory />


### PR DESCRIPTION
This PR changes the example persistent data config to keep also other directories, like `theme`, `plugins` etc. in the volume. The whole `upload` directory is intended for persistent data and current example config causes e.g. lose of theme modifications on the container upgrade.

In addition, the "Known issues" section discusses the topic as well as another issue with the Apache, which tries to use its own port when redirecting to canonical URLs. When put behind another proxy listening on different ports, it produces URLs not accessible by the client.

Close #196 