### PR TITLE
Make request.baseUrl conditional for LimeSurvey 6 images

### DIFF
--- a/6.0/apache/entrypoint.sh
+++ b/6.0/apache/entrypoint.sh
@@ -103,6 +103,14 @@ else
         echo 'Info: Setting PublicURL'
     fi
 
+    REQUEST_CONFIG=""
+    if [ -n "$BASE_URL" ]; then
+        REQUEST_CONFIG="
+    'request' => array(
+      'baseUrl' => '$BASE_URL',
+     ),"
+    fi
+
     cat <<EOF > application/config/config.php
 <?php if (!defined('BASEPATH')) exit('No direct script access allowed');
 return array(
@@ -125,9 +133,7 @@ return array(
       'rules' => array(),
       'showScriptName' => $SHOW_SCRIPT_NAME,
     ),
-    'request' => array(
-      'baseUrl' => '$BASE_URL',
-     ),
+$REQUEST_CONFIG
   ),
   'config'=>array(
     'publicurl'=>'$PUBLIC_URL',

--- a/6.0/fpm-alpine/entrypoint.sh
+++ b/6.0/fpm-alpine/entrypoint.sh
@@ -96,6 +96,14 @@ else
         echo 'Info: Setting PublicURL'
     fi
 
+    REQUEST_CONFIG=""
+    if [ -n "$BASE_URL" ]; then
+        REQUEST_CONFIG="
+    'request' => array(
+      'baseUrl' => '$BASE_URL',
+     ),"
+    fi
+
     cat <<EOF > application/config/config.php
 <?php if (!defined('BASEPATH')) exit('No direct script access allowed');
 return array(
@@ -118,9 +126,7 @@ return array(
       'rules' => array(),
       'showScriptName' => $SHOW_SCRIPT_NAME,
     ),
-    'request' => array(
-      'baseUrl' => '$BASE_URL',
-     ),
+$REQUEST_CONFIG
   ),
   'config'=>array(
     'publicurl'=>'$PUBLIC_URL',

--- a/6.0/fpm/entrypoint.sh
+++ b/6.0/fpm/entrypoint.sh
@@ -96,6 +96,14 @@ else
         echo 'Info: Setting PublicURL'
     fi
 
+    REQUEST_CONFIG=""
+    if [ -n "$BASE_URL" ]; then
+        REQUEST_CONFIG="
+    'request' => array(
+      'baseUrl' => '$BASE_URL',
+     ),"
+    fi
+
     cat <<EOF > application/config/config.php
 <?php if (!defined('BASEPATH')) exit('No direct script access allowed');
 return array(
@@ -118,9 +126,7 @@ return array(
       'rules' => array(),
       'showScriptName' => $SHOW_SCRIPT_NAME,
     ),
-    'request' => array(
-      'baseUrl' => '$BASE_URL',
-     ),
+$REQUEST_CONFIG
   ),
   'config'=>array(
     'publicurl'=>'$PUBLIC_URL',


### PR DESCRIPTION
This changes the LimeSurvey 6 entrypoints so `request.baseUrl` is only written to `application/config/config.php` when the `BASE_URL` environment variable is explicitly set.

When `BASE_URL` is unset, the generated config now omits `request.baseUrl`. This lets Yii auto-detect the correct base path, which fixes KCFinder/Resources tab behavior without patching LimeSurvey application files.

I verified locally that:
- with `BASE_URL` unset, `request.baseUrl` is absent from the generated config
- KCFinder then resolves its base path correctly
- the Resources tab upload/refresh behavior works
- with `BASE_URL=/limesurvey`, the generated config still contains `'baseUrl' => '/limesurvey'`

Note: If this is accepted, the README should probably clarify the difference between `PUBLIC_URL` and `BASE_URL`.

Suggested wording:
- `PUBLIC_URL` should be used for the public full URL, for example `https://example.org`.
- `BASE_URL` should only be set for intentional subdirectory/base-path deployments, for example `/limesurvey`.
- If `BASE_URL` is unset, `request.baseUrl` is omitted from the generated LimeSurvey config so Yii can auto-detect the correct base path.