### PR TITLE
feat: add HOST_INFO environment variable to configure base URL sent in LimeSurvey responses

### DIFF
--- a/5.0/apache/entrypoint.sh
+++ b/5.0/apache/entrypoint.sh
@@ -42,6 +42,7 @@ file_env 'ADMIN_PASSWORD'
 
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
+HOST_INFO=${HOST_INFO:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
 TABLE_SESSION=${TABLE_SESSION:-}
@@ -127,7 +128,8 @@ return array(
     ),
     'request' => array(
       'baseUrl' => '$BASE_URL',
-     ),
+      'hostInfo' => '$HOST_INFO',
+    ),
   ),
   'config'=>array(
     'publicurl'=>'$PUBLIC_URL',

--- a/5.0/fpm-alpine/entrypoint.sh
+++ b/5.0/fpm-alpine/entrypoint.sh
@@ -42,6 +42,7 @@ file_env 'ADMIN_PASSWORD'
 
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
+HOST_INFO=${HOST_INFO:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
 TABLE_SESSION=${TABLE_SESSION:-}
@@ -120,7 +121,8 @@ return array(
     ),
     'request' => array(
       'baseUrl' => '$BASE_URL',
-     ),
+      'hostInfo' => '$HOST_INFO',
+    ),
   ),
   'config'=>array(
     'publicurl'=>'$PUBLIC_URL',

--- a/5.0/fpm/entrypoint.sh
+++ b/5.0/fpm/entrypoint.sh
@@ -42,6 +42,7 @@ file_env 'ADMIN_PASSWORD'
 
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
+HOST_INFO=${HOST_INFO:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
 TABLE_SESSION=${TABLE_SESSION:-}
@@ -120,7 +121,8 @@ return array(
     ),
     'request' => array(
       'baseUrl' => '$BASE_URL',
-     ),
+      'hostInfo' => '$HOST_INFO',
+    ),
   ),
   'config'=>array(
     'publicurl'=>'$PUBLIC_URL',

--- a/6.0/apache/entrypoint.sh
+++ b/6.0/apache/entrypoint.sh
@@ -42,6 +42,7 @@ file_env 'ADMIN_PASSWORD'
 
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
+HOST_INFO=${HOST_INFO:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
 TABLE_SESSION=${TABLE_SESSION:-}
@@ -104,11 +105,12 @@ else
     fi
 
     REQUEST_CONFIG=""
-    if [ -n "$BASE_URL" ]; then
+    if [ -n "$BASE_URL" || -n "$HOST_INFO" ]; then
         REQUEST_CONFIG="
     'request' => array(
       'baseUrl' => '$BASE_URL',
-     ),"
+      'hostInfo' => '$HOST_INFO',
+    ),"
     fi
 
     cat <<EOF > application/config/config.php

--- a/6.0/fpm-alpine/entrypoint.sh
+++ b/6.0/fpm-alpine/entrypoint.sh
@@ -42,6 +42,7 @@ file_env 'ADMIN_PASSWORD'
 
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
+HOST_INFO=${HOST_INFO:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
 TABLE_SESSION=${TABLE_SESSION:-}
@@ -97,11 +98,12 @@ else
     fi
 
     REQUEST_CONFIG=""
-    if [ -n "$BASE_URL" ]; then
+    if [ -n "$BASE_URL" || -n "$HOST_INFO" ]; then
         REQUEST_CONFIG="
     'request' => array(
       'baseUrl' => '$BASE_URL',
-     ),"
+      'hostInfo' => '$HOST_INFO',
+    ),"
     fi
 
     cat <<EOF > application/config/config.php

--- a/6.0/fpm/entrypoint.sh
+++ b/6.0/fpm/entrypoint.sh
@@ -42,6 +42,7 @@ file_env 'ADMIN_PASSWORD'
 
 BASE_URL=${BASE_URL:-}
 PUBLIC_URL=${PUBLIC_URL:-}
+HOST_INFO=${HOST_INFO:-}
 URL_FORMAT=${URL_FORMAT:-'path'}
 SHOW_SCRIPT_NAME=${SHOW_SCRIPT_NAME:-'true'}
 TABLE_SESSION=${TABLE_SESSION:-}
@@ -97,11 +98,12 @@ else
     fi
 
     REQUEST_CONFIG=""
-    if [ -n "$BASE_URL" ]; then
+    if [ -n "$BASE_URL" || -n "$HOST_INFO" ]; then
         REQUEST_CONFIG="
     'request' => array(
       'baseUrl' => '$BASE_URL',
-     ),"
+      'hostInfo' => '$HOST_INFO',
+    ),"
     fi
 
     cat <<EOF > application/config/config.php

--- a/README.md
+++ b/README.md
@@ -104,34 +104,34 @@ If you are running LimeSurvey behind a Reverse Proxy you might need some additio
 
 # Environment Variables
 
-| Parameter       | Description                               |
-| ---------       | -----------                               |
-| DB_TYPE         | Database Type to use. mysql or pgsql      |
-| DB_HOST         | Database server hostname                  |
-| DB_PORT         | Database server port                      |
-| DB_SOCK         | Database unix socket instead of host/port |
-| DB_NAME         | Database name                             |
-| DB_TABLE_PREFIX | Database table prefix; set this to a single whitespace if you don't want a table prefix. |
-| DB_MYSQL_ENGINE | MySQL engine used for survey tables (values: MyISAM, InnoDB, default: MyISAM)       |
-| DB_USERNAME     | Database user                             |
-| DB_PASSWORD     | Database user's password                  |
-| ADMIN_USER      | Initial LimeSurvey Admin Username (for signing into admin panel)             |
-| ADMIN_NAME      | Initial LimeSurvey Admin Name             |
-| ADMIN_EMAIL     | Initial LimeSurvey Admin Email            |
-| ADMIN_PASSWORD  | Initial LimeSurvey Admin Password (for signing into admin panel)         |
-| PUBLIC_URL      | Public URL for public scripts             |
-| BASE_URL        | Application Base URL                      |
-| URL_FORMAT      | URL Format. path or get                   |
-| TABLE_SESSION   | Enable table sessions (true)              |
-| SHOW_SCRIPT_NAME | Script name in URL (true\|false). Default: true |
-| DEBUG           | Debug level (0, 1, 2). Default: 0         |
-| DEBUG_SQL       | SQL Debug level (0, 1, 2). Default 0      |
-| ENCRYPT_KEYPAIR  | Data encryption keypair                  |
-| ENCRYPT_PUBLIC_KEY | Data encryption public key             |
-| ENCRYPT_SECRET_KEY | Data encryption secret key             |
-| ENCRYPT_NONCE      | Data encryption nonce (used in 5.0 and higher) |
-| ENCRYPT_SECRET_BOX_KEY | Data encryption secret box key (used in 5.0 and higher) |
-| LISTEN_PORT     | Apache: Listen port. Default: 8080        |
+| Parameter              | Description                                                                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| DB_TYPE                | Database Type to use. (mysql\|pgsql). Default: mysql                                                                                      |
+| DB_HOST                | Database server hostname. Default: mysql                                                                                                  |
+| DB_PORT                | Database server port. Default: 3306                                                                                                       |
+| DB_SOCK                | Database unix socket instead of host/port                                                                                                 |
+| DB_NAME                | Database name. Default: limesurvey                                                                                                        |
+| DB_TABLE_PREFIX        | Database table prefix; set this to a single whitespace if you don't want a table prefix. Default: lime_                                   |
+| DB_MYSQL_ENGINE        | MySQL engine used for survey tables (MyISAM\_InnoDB). Default: MyISAM                                                                     |
+| DB_USERNAME            | Database user. Default: limesurvey                                                                                                        |
+| DB_PASSWORD            | Database user's password                                                                                                                  |
+| ADMIN_USER             | Initial LimeSurvey Admin Username (for signing into admin panel). Default: admin                                                          |
+| ADMIN_NAME             | Initial LimeSurvey Admin Name. Default: admin                                                                                             |
+| ADMIN_EMAIL            | Initial LimeSurvey Admin Email. Default: foobar@example.com                                                                               |
+| ADMIN_PASSWORD         | Initial LimeSurvey Admin Password (for signing into admin panel)                                                                          |
+| PUBLIC_URL             | Public URL for public scripts                                                                                                             |
+| BASE_URL               | Application Base URL                                                                                                                      |
+| URL_FORMAT             | URL Format. (path\|get). Default: path                                                                                                    |
+| TABLE_SESSION          | Enable table sessions (true)                                                                                                              |
+| SHOW_SCRIPT_NAME       | Script name in URL (true\|false). Default: true                                                                                           |
+| DEBUG                  | Debug level (0\_1\_2). Default: 0                                                                                                         |
+| DEBUG_SQL              | SQL Debug level (0\_1\_2). Default 0                                                                                                      |
+| ENCRYPT_KEYPAIR        | Data encryption keypair                                                                                                                   |
+| ENCRYPT_PUBLIC_KEY     | Data encryption public key                                                                                                                |
+| ENCRYPT_SECRET_KEY     | Data encryption secret key                                                                                                                |
+| ENCRYPT_NONCE          | Data encryption nonce (used in 5.0 and higher)                                                                                            |
+| ENCRYPT_SECRET_BOX_KEY | Data encryption secret box key (used in 5.0 and higher)                                                                                   |
+| LISTEN_PORT            | Apache: Listen port. Default: 8080                                                                                                        |
 
 Sensitive information can also be passed `_FILE` to the following environment variables to load the values from the given file path. Example `DB_PASSWORD_FILE=/run/secrets/db_password`.
 

--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ If you are running LimeSurvey behind a Reverse Proxy you might need some additio
 
 | Parameter              | Description                                                                                                                               |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| DB_TYPE                | Database Type to use. (mysql\|pgsql). Default: mysql                                                                                      |
+| DB_TYPE                | Database Type to use. (mysql|pgsql). Default: mysql                                                                                       |
 | DB_HOST                | Database server hostname. Default: mysql                                                                                                  |
 | DB_PORT                | Database server port. Default: 3306                                                                                                       |
 | DB_SOCK                | Database unix socket instead of host/port                                                                                                 |
 | DB_NAME                | Database name. Default: limesurvey                                                                                                        |
 | DB_TABLE_PREFIX        | Database table prefix; set this to a single whitespace if you don't want a table prefix. Default: lime_                                   |
-| DB_MYSQL_ENGINE        | MySQL engine used for survey tables (MyISAM\_InnoDB). Default: MyISAM                                                                     |
+| DB_MYSQL_ENGINE        | MySQL engine used for survey tables (MyISAM|InnoDB). Default: MyISAM                                                                      |
 | DB_USERNAME            | Database user. Default: limesurvey                                                                                                        |
 | DB_PASSWORD            | Database user's password                                                                                                                  |
 | ADMIN_USER             | Initial LimeSurvey Admin Username (for signing into admin panel). Default: admin                                                          |
@@ -121,12 +121,12 @@ If you are running LimeSurvey behind a Reverse Proxy you might need some additio
 | ADMIN_PASSWORD         | Initial LimeSurvey Admin Password (for signing into admin panel)                                                                          |
 | PUBLIC_URL             | Public URL for public scripts                                                                                                             |
 | BASE_URL               | Application Base URL                                                                                                                      |
-| HOST_INFO               | Enforce a certain ULR base (see [`hostInfo` key in documentation](https://www.limesurvey.org/manual/Optional_settings#Request_settings)) |
+| HOST_INFO              | Enforce a certain URL base (see [`hostInfo` key in documentation](https://www.limesurvey.org/manual/Optional_settings#Request_settings))  |
 | URL_FORMAT             | URL Format. (path\|get). Default: path                                                                                                    |
 | TABLE_SESSION          | Enable table sessions (true)                                                                                                              |
-| SHOW_SCRIPT_NAME       | Script name in URL (true\|false). Default: true                                                                                           |
-| DEBUG                  | Debug level (0\_1\_2). Default: 0                                                                                                         |
-| DEBUG_SQL              | SQL Debug level (0\_1\_2). Default 0                                                                                                      |
+| SHOW_SCRIPT_NAME       | Script name in URL (true|false). Default: true                                                                                            |
+| DEBUG                  | Debug level (0|1|2). Default: 0                                                                                                           |
+| DEBUG_SQL              | SQL Debug level (0|1|2). Default 0                                                                                                        |
 | ENCRYPT_KEYPAIR        | Data encryption keypair                                                                                                                   |
 | ENCRYPT_PUBLIC_KEY     | Data encryption public key                                                                                                                |
 | ENCRYPT_SECRET_KEY     | Data encryption secret key                                                                                                                |

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ If you are running LimeSurvey behind a Reverse Proxy you might need some additio
 | ADMIN_PASSWORD         | Initial LimeSurvey Admin Password (for signing into admin panel)                                                                          |
 | PUBLIC_URL             | Public URL for public scripts                                                                                                             |
 | BASE_URL               | Application Base URL                                                                                                                      |
+| HOST_INFO               | Enforce a certain ULR base (see [`hostInfo` key in documentation](https://www.limesurvey.org/manual/Optional_settings#Request_settings)) |
 | URL_FORMAT             | URL Format. (path\|get). Default: path                                                                                                    |
 | TABLE_SESSION          | Enable table sessions (true)                                                                                                              |
 | SHOW_SCRIPT_NAME       | Script name in URL (true\|false). Default: true                                                                                           |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This image is also available in a `rootless` variant with `www-data` as default 
 
 To change to Apache Webserver configuration, mount a Volume into the Container at:
 
- - `/etc/apache2/sites-available/000-default.conf`
+- `/etc/apache2/sites-available/000-default.conf`
 
 See the example configuration provided.
 
@@ -69,7 +69,7 @@ The entrypoint will create a new config.php if none is provided and run the Lime
 
 To change to LimeSurvey configuration, you can mount a Volume into the Container at:
 
- - `/my-data/config.php:/var/www/html/application/config/config.php`
+- `/my-data/config.php:/var/www/html/application/config/config.php`
 
 **Hint**: If this configuration is present before the installation, the LimeSurvey Web Installer will not run automatically.
 
@@ -77,9 +77,9 @@ To change to LimeSurvey configuration, you can mount a Volume into the Container
 
 LimeSurvey version 4.0 and newer support data encryption, this image give you these options:
 
-* Provide a security.php file directly (volume)
-* Provide encryption keys for the `security.php` file (environment variables)
-* Provide nothing and get a non-persistent `security.php` file
+- Provide a security.php file directly (volume)
+- Provide encryption keys for the `security.php` file (environment variables)
+- Provide nothing and get a non-persistent `security.php` file
 
 For further details on the settings see: https://manual.limesurvey.org/Data_encryption
 
@@ -87,9 +87,9 @@ For further details on the settings see: https://manual.limesurvey.org/Data_encr
 
 If you are running LimeSurvey behind a Reverse Proxy you might need some additional configuration in the Proxy. For example:
 
-* Apache: `ProxyPreserveHost On`
-* Nginx: `fastcgi_param HTTP_HOST my-survey.example.local;`
-* Traefik: Set the Host Header explicitly via a customRequestHeaders
+- Apache: `ProxyPreserveHost On`
+- Nginx: `fastcgi_param HTTP_HOST my-survey.example.local;`
+- Traefik: Set the Host Header explicitly via a customRequestHeaders
 
 ## Traefik example
 
@@ -220,6 +220,7 @@ When running LimeSurvey behind a reverse proxy with a subdirectory (i.e. example
 This might be fixed by setting the HTTP Host Header in the reverse proxy explicitly.
 
 See:
+
 - https://github.com/martialblog/docker-limesurvey/issues/127
 
 ## Updating or rebuilding container removes themes/plugins/...
@@ -230,7 +231,7 @@ volume for survey uploads. In such a situation, any rebuild of the container wil
 To keep them persistent, you need to ensure that all subdirectories of `upload` are stored in a volume.
 
 The easiest way is to mount the whole `/var/www/html/upload`. If you want to update an existing deployment
-from previous configuration, please keep in mind that just changing the mount path may cause data loss 
+from previous configuration, please keep in mind that just changing the mount path may cause data loss
 (e.g. already uploaded themes). Please backup your data from the container before any modifications.
 You may also consider separated volumes for each subdirectory.
 


### PR DESCRIPTION
Add the `hostInfo` optional setting customisable through `HOST_INFO` environment variable.

It follows discussion in https://github.com/martialblog/docker-limesurvey/issues/184. This option is required to set the base URL. For example, it sets the `Location` header in LimeSurvey server responses, which may be useful if LimeSurvey docker container is behind a reverse proxy.

It is still not cleared to me how `hostInfo` is different from `baseUrl`. Maybe it replaces it as `baseUrl` is no longer mentioned in [LimeSurvey optional settings documentation](https://www.limesurvey.org/manual/Optional_settings#Request_settings). Maybe the same environment variable could be safely used to set both `hostInfo` and `baseUrl`. But in my specific case (need to set `hostInfo` to https URL while LimeSurvey send back http URL `Location` as LimeSurvey is not in force https mode as running behind a nginx reverse proxy), only `hostInfo` was fixing the issue.

In this pull request, README.md documentation is also updated to add all default values (some were missing).