### PR TITLE
doc: indicate that `upload` host directory must already have base content

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To preserve the uploaded files assign the upload folder into a volume. See *dock
 
 Path: `/var/www/html/upload`
 
-**Hint**: The mounted directory must be owned by the webserver user (e.g. www-data)
+**Hint**: The mounted directory must be owned by the webserver user (e.g. www-data). The host folder must already have the base content from LimeSurvey on https://community.limesurvey.org/downloads/.
 
 # LimeSurvey configuration
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,8 +16,9 @@ services:
       - ADMIN_EMAIL=admin@example.com
       - PUBLIC_URL=foobar.com
     volumes:
-      # All subdirectories of the upload may contain
-      # data intended to be persistent (e.g. themes)
+      # TODO Update storage location as desired. All subdirectories of the `upload` may contain
+      # data intended to be persistent (e.g. themes). `upload` host directory must already have the
+      # base content from LimeSurvey on https://community.limesurvey.org/downloads/
       - limesurvey:/var/www/html/upload
     ports:
       - 8080:8080

--- a/docker-compose.pgsql.yml
+++ b/docker-compose.pgsql.yml
@@ -4,8 +4,10 @@ services:
       context: 6.0/apache/
       dockerfile: Dockerfile
     volumes:
-      # TODO Update storage location as desired
-      - ./lime-data/surveys:/var/www/html/upload/surveys
+      # TODO Update storage location as desired. All subdirectories of the `upload` may contain
+      # data intended to be persistent (e.g. themes). `upload` host directory must already have the
+      # base content from LimeSurvey on https://community.limesurvey.org/downloads/
+      - ./lime-data/upload:/var/www/html/upload
     networks:
       - limesurvey-db
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ services:
       context: 6.0/apache/
       dockerfile: Dockerfile
     volumes:
-      # TODO Update storage location as desired
-      - ./surveys:/var/www/html/upload/surveys
+      # TODO Update storage location as desired. All subdirectories of the `upload` may contain
+      # data intended to be persistent (e.g. themes). `upload` host directory must already have the
+      # base content from LimeSurvey on https://community.limesurvey.org/downloads/
+      - ./lime-data/upload:/var/www/html/upload
     networks:
       - limesurvey-db
     ports:


### PR DESCRIPTION
From my understanding, this closes #246 based on [@martialblog comment](https://github.com/martialblog/docker-limesurvey/issues/246#issuecomment-4521546626). https://github.com/martialblog/docker-limesurvey/issues/201 seems to also relate to the same issue.