### PR TITLE
ci: Fix 7.x image publishing workflow trigger to run on `7.*` tags

### DIFF
--- a/.github/workflows/build-latest-container-images.yaml
+++ b/.github/workflows/build-latest-container-images.yaml
@@ -2,7 +2,7 @@ name: Publish Latest Container Images
 on:
   push:
     tags:
-      - '6.*'
+      - '7.*'
 
 jobs:
   lint_dockerfiles:
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         dockerfile:
-          - 6.0/apache/Dockerfile
-          - 6.0/fpm-alpine/Dockerfile
-          - 6.0/fpm/Dockerfile
+          - 7.0/apache/Dockerfile
+          - 7.0/fpm-alpine/Dockerfile
+          - 7.0/fpm/Dockerfile
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0


### PR DESCRIPTION
I think I missed this in https://github.com/martialblog/docker-limesurvey/pull/297
