### PR TITLE
Downgrade PHP from 8.5 to 8.4 to fix `console.php` failing to execute

### DIFF
--- a/7.0/apache/Dockerfile
+++ b/7.0/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/php:8.5-apache-trixie
+FROM docker.io/php:8.4-apache-trixie
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies

--- a/7.0/fpm-alpine/Dockerfile
+++ b/7.0/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/php:8.5-fpm-alpine
+FROM docker.io/php:8.4-fpm-alpine
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies

--- a/7.0/fpm/Dockerfile
+++ b/7.0/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/php:8.5-fpm-trixie
+FROM docker.io/php:8.4-fpm-trixie
 LABEL maintainer="markus@martialblog.de"
 
 # Install OS dependencies

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ $ docker volume rm docker-limesurvey_lime
 
 ## Upgrading to 7.0 from 6.x
 
-The LimeSurvey 7 Images will use PHP 8.5 and Debian Trixie as Base Images.
+The LimeSurvey 7 Images will use PHP 8.4 and Debian Trixie as Base Images.
 
 Note that, the php-imap extention has been removed from Debian Trixie and this container image.
 

--- a/tests/apache-tests.yaml
+++ b/tests/apache-tests.yaml
@@ -52,3 +52,9 @@ commandTests:
     command: "php"
     args: ["-m"]
     expectedOutput: ["ldap", "zip", "pdo_mysql", "pdo_sqlite", "gd", "mbstring", "PDO"]
+  - name: "Console command runs without PHP errors"
+    command: "php"
+    args: ["application/commands/console.php"]
+    exitCode: 1
+    expectedOutput: ["Yii command runner"]
+    excludedOutput: ["Deprecated", "PHP Error"]

--- a/tests/apache-tests.yaml
+++ b/tests/apache-tests.yaml
@@ -54,7 +54,7 @@ commandTests:
     expectedOutput: ["ldap", "zip", "pdo_mysql", "pdo_sqlite", "gd", "mbstring", "PDO"]
   - name: "Console command runs without PHP errors"
     command: "php"
-    args: ["application/commands/console.php"]
-    exitCode: 1
-    expectedOutput: ["Yii command runner"]
+    args: ["application/commands/console.php", "flushassets"]
+    exitCode: 0
+    expectedOutput: ["Flushing assets"]
     excludedOutput: ["Deprecated", "PHP Error"]

--- a/tests/fpm-alpine-tests.yaml
+++ b/tests/fpm-alpine-tests.yaml
@@ -52,3 +52,9 @@ commandTests:
     command: "php"
     args: ["-m"]
     expectedOutput: ["ldap", "zip", "pdo_mysql", "pdo_sqlite", "gd", "mbstring", "PDO"]
+  - name: "Console command runs without PHP errors"
+    command: "php"
+    args: ["application/commands/console.php"]
+    exitCode: 1
+    expectedOutput: ["Yii command runner"]
+    excludedOutput: ["Deprecated", "PHP Error"]

--- a/tests/fpm-alpine-tests.yaml
+++ b/tests/fpm-alpine-tests.yaml
@@ -54,7 +54,7 @@ commandTests:
     expectedOutput: ["ldap", "zip", "pdo_mysql", "pdo_sqlite", "gd", "mbstring", "PDO"]
   - name: "Console command runs without PHP errors"
     command: "php"
-    args: ["application/commands/console.php"]
-    exitCode: 1
-    expectedOutput: ["Yii command runner"]
+    args: ["application/commands/console.php", "flushassets"]
+    exitCode: 0
+    expectedOutput: ["Flushing assets"]
     excludedOutput: ["Deprecated", "PHP Error"]


### PR DESCRIPTION
Closes https://github.com/martialblog/docker-limesurvey/issues/311
